### PR TITLE
feat(nonupgradable contracts): feature/addDefaultBreakerValues

### DIFF
--- a/script/upgrades/MU01/deploy/MU01-01-Create-Nonupgradeable-Contracts.sol
+++ b/script/upgrades/MU01/deploy/MU01-01-Create-Nonupgradeable-Contracts.sol
@@ -5,6 +5,7 @@ import { console2 } from "forge-std/Script.sol";
 import { Script } from "script/utils/Script.sol";
 import { Chain } from "script/utils/Chain.sol";
 
+import { FixidityLib } from "mento-core/contracts/common/FixidityLib.sol";
 import { ConstantSumPricingModule } from "mento-core/contracts/ConstantSumPricingModule.sol";
 import { ConstantProductPricingModule } from "mento-core/contracts/ConstantProductPricingModule.sol";
 import { MedianDeltaBreaker } from "mento-core/contracts/MedianDeltaBreaker.sol";
@@ -12,7 +13,7 @@ import { ValueDeltaBreaker } from "mento-core/contracts/ValueDeltaBreaker.sol";
 import { ISortedOracles } from "mento-core/contracts/interfaces/ISortedOracles.sol";
 
 /*
- forge script MU01_CreateNonupgradeableContracts --rpc-url $RPC_URL
+ forge script MU01_CreateNonupgradeableContracts --rpc-url $RPC_URL --private-key $PRIVATE_KEY
                              --broadcast --legacy 
                              --verify --verifier sourcify 
 */
@@ -24,11 +25,11 @@ contract MU01_CreateNonupgradeableContracts is Script {
 
   function run() public {
     //TODO: We need to get the correct values for these
-    uint256 medianDeltaBreakerCooldown = 0;
-    uint256 medianDeltaBreakerThreshold = 0;
+    uint256 medianDeltaBreakerCooldown = 30 minutes;
+    uint256 medianDeltaBreakerThreshold = FixidityLib.newFixedFraction(3, 100).unwrap(); // 0.03
 
-    uint256 valueDeltaBreakerCooldown = 0;
-    uint256 valueDeltaBreakerThreshold = 0;
+    uint256 valueDeltaBreakerCooldown = 1 seconds;
+    uint256 valueDeltaBreakerThreshold = FixidityLib.newFixedFraction(5, 1000).unwrap(); // 0.005
 
     address sortedOracles = contracts.celoRegistry("SortedOracles");
 


### PR DESCRIPTION
### Description

This PR adds real default values to median and value breaker deployment.

To verify the default values and how I chose them, see the issue description: https://github.com/mento-protocol/mento-core/issues/174

### Other changes

-

### Tested
- Yes, test-deployed to Baklava 

### Related issues

- Fixes https://github.com/mento-protocol/mento-core/issues/174

### Backwards compatibility

yes should be fully

### Documentation
- https://github.com/mento-protocol/mento-core/issues/174
