### PR TITLE
feat: add medianDeltaBreakear deployment script

### DIFF
--- a/script/upgrades/MU01/deploy/MU01-05-Deploy-BreakerBox.sol
+++ b/script/upgrades/MU01/deploy/MU01-05-Deploy-BreakerBox.sol
@@ -9,11 +9,11 @@ import { BreakerBox } from "mento-core/contracts/BreakerBox.sol";
 import { ISortedOracles } from "mento-core/contracts/interfaces/ISortedOracles.sol";
 
 /*
- forge script MU02_DeployBreakerBox --rpc-url $RPC_URL
-                             --broadcast --legacy 
-                             --verify --verifier sourcify 
+ forge script MU01_DeployBreakerBox --rpc-url $RPC_URL
+                             --broadcast --legacy
+                             --verify --verifier sourcify
 */
-contract MU02_DeployBreakerBox is Script {
+contract MU01_DeployBreakerBox is Script {
   BreakerBox private breakerBox;
 
   function run() public {

--- a/script/upgrades/MU01/deploy/MU01-06-Deploy-MedianDeltaBreaker.sol
+++ b/script/upgrades/MU01/deploy/MU01-06-Deploy-MedianDeltaBreaker.sol
@@ -8,12 +8,13 @@ import { Chain } from "script/utils/Chain.sol";
 import { MedianDeltaBreaker } from "mento-core/contracts/MedianDeltaBreaker.sol";
 import { ISortedOracles } from "mento-core/contracts/interfaces/ISortedOracles.sol";
 
+
 /*
- forge script MU01_Phase2_DeployMedianDeltaBreaker --rpc-url $RPC_URL
+ forge script MU01_DeployMedianDeltaBreaker --rpc-url $RPC_URL
                              --broadcast --legacy
                              --verify --verifier sourcify
 */
-contract MU02_DeployMedianDeltaBreaker is Script {
+contract MU01_DeployMedianDeltaBreaker is Script {
   MedianDeltaBreaker private medianDeltaBreaker;
 
   function run() public {

--- a/script/upgrades/MU02/MU02-01-Deploy-MedianDeltaBreaker.sol
+++ b/script/upgrades/MU02/MU02-01-Deploy-MedianDeltaBreaker.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.5.13;
+
+import { console2 } from "forge-std/Script.sol";
+import { Script } from "script/utils/Script.sol";
+import { Chain } from "script/utils/Chain.sol";
+
+import { MedianDeltaBreaker } from "mento-core/contracts/MedianDeltaBreaker.sol";
+import { ISortedOracles } from "mento-core/contracts/interfaces/ISortedOracles.sol";
+
+/*
+ forge script MU01_Phase2_DeployMedianDeltaBreaker --rpc-url $RPC_URL
+                             --broadcast --legacy
+                             --verify --verifier sourcify
+*/
+contract MU02_DeployMedianDeltaBreaker is Script {
+  MedianDeltaBreaker private medianDeltaBreaker;
+
+  function run() public {
+    uint256 medianDeltaBreakerCooldown = 0;
+    uint256 medianDeltaBreakerThreshold = 0;
+
+    address governance = contracts.celoRegistry("Governance");
+    address sortedOracles = contracts.celoRegistry("SortedOracles");
+
+    address[] memory __rateFeedIDs = new address[](0);
+    uint256[] memory __rateChangeThresholds = new uint256[](0);
+    uint256[] memory __cooldowns = new uint256[](0);
+
+    vm.startBroadcast(Chain.deployerPrivateKey());
+    {
+      medianDeltaBreaker = new MedianDeltaBreaker(
+        medianDeltaBreakerCooldown,
+        medianDeltaBreakerThreshold,
+        ISortedOracles(sortedOracles),
+        __rateFeedIDs,
+        __rateChangeThresholds,
+        __cooldowns
+      );
+      medianDeltaBreaker.transferOwnership(governance);
+    }
+    vm.stopBroadcast();
+
+    console2.log("----------");
+    console2.log("MedianDeltaBreaker deployed at", address(medianDeltaBreaker));
+    console2.log("MedianDeltaBreaker(%s) ownership transferred to %s", address(medianDeltaBreaker), governance);
+    console2.log("----------");
+  }
+}


### PR DESCRIPTION
### Description

This adds the script for deploying the median delta breaker with default/empty configuration and transferring it to governance so that we can later re-configure it with the right parameters in the MU02 activation CGP.

### Other changes

-

### Tested

Ran the deployment simulation locally

### Related issues

- Fixes https://github.com/mento-protocol/mento-deployment/issues/59

### Backwards compatibility

Yes, since the old constructor didn't change

### Documentation

-