### PR TITLE
Fix/mu03 exchange destruction

### DIFF
--- a/script/upgrades/MU03/MU03.sol
+++ b/script/upgrades/MU03/MU03.sol
@@ -127,8 +127,6 @@ contract MU03 is IMentoUpgrade, GovernanceScript {
     require(transactions.length == 0, "buildProposal() should only be called once");
     MU03Config.MU03 memory config = MU03Config.get(contracts);
 
-    //proposal_cleanUp(config);
-
     proposal_addEUROCToPartialReserve();
     proposal_updateBiPoolManagerImplementation();
     proposal_updateBrokerImplementation();
@@ -141,31 +139,6 @@ contract MU03 is IMentoUpgrade, GovernanceScript {
     proposal_configureValueDeltaBreaker0(config);
 
     return transactions;
-  }
-
-  function proposal_cleanUp(MU03Config.MU03 memory config) private {
-    transactions.push(
-      ICeloGovernance.Transaction(
-        0,
-        contracts.deployed("BiPoolManagerProxy"),
-        abi.encodeWithSelector(
-          IBiPoolManager(0).destroyExchange.selector,
-          getExchangeId(config.cEURUSDC.asset0, config.cEURUSDC.asset1, config.cEURUSDC.isConstantSum),
-          4
-        )
-      )
-    );
-    transactions.push(
-      ICeloGovernance.Transaction(
-        0,
-        contracts.deployed("BiPoolManagerProxy"),
-        abi.encodeWithSelector(
-          IBiPoolManager(0).destroyExchange.selector,
-          getExchangeId(config.cBRLUSDC.asset0, config.cBRLUSDC.asset1, config.cBRLUSDC.isConstantSum),
-          4
-        )
-      )
-    );
   }
 
   function proposal_addEUROCToPartialReserve() private {
@@ -241,7 +214,7 @@ contract MU03 is IMentoUpgrade, GovernanceScript {
 
     bool biPoolManagerInitialized = BiPoolManagerProxy(biPoolManagerProxyAddress)._getImplementation() != address(0);
     if (biPoolManagerInitialized) {
-      // Destroy cUSD/brdgedUSDC exchange -> since ConstantSum has changed
+      // Destroy cUSD/brdgedUSDC exchange -> since ConstantSum logic has changed
       bytes32 cUSDUSDCExchangeId = getExchangeId(
         config.cUSDUSDC.asset0,
         config.cUSDUSDC.asset1,
@@ -251,7 +224,7 @@ contract MU03 is IMentoUpgrade, GovernanceScript {
         ICeloGovernance.Transaction(
           0,
           contracts.deployed("BiPoolManagerProxy"),
-          //it's ok to hardcode the index here since the transaction would fail if the index and identifier don't match
+          //it's ok to hardcode the index here since the transaction would fail if index and identifier don't match
           abi.encodeWithSelector(IBiPoolManager(0).destroyExchange.selector, cUSDUSDCExchangeId, 3)
         )
       );

--- a/script/upgrades/MU03/MU03Checks.sol
+++ b/script/upgrades/MU03/MU03Checks.sol
@@ -108,6 +108,7 @@ contract MU03Checks is Script, Test {
     setUp();
 
     verifyOwner();
+    //verifyExchangeLength();
     verifyEUROCSetUp();
     verifyBiPoolManager();
     verifySortedOracles();
@@ -134,6 +135,19 @@ contract MU03Checks is Script, Test {
     );
     require(Broker(broker).owner() == governance, "Broker ownership not transferred to governance");
     console2.log("Contract ownerships transferred to governance 🤝");
+  }
+
+  function verifyExchangeLength() internal view {
+    bytes32[] memory exchanges = BiPoolManager(biPoolManagerProxy).getExchangeIds();
+    if (exchanges.length != 4) {
+      console2.log(
+        "The number of expected exchanges: %s does not match the number of deployed exchanges: %s.",
+        4,
+        exchanges.length
+      );
+      revert("Number of expected exchanges does not match the number of deployed exchanges. See logs.");
+    }
+    console2.log("\tNumber of exchanges matches the expected number of exchanges 🤘🏼");
   }
 
   function verifyEUROCSetUp() internal view {

--- a/script/upgrades/MU03/MU03Checks.sol
+++ b/script/upgrades/MU03/MU03Checks.sol
@@ -544,12 +544,12 @@ contract MU03Checks is Script, Test {
 
     console2.log("\n== Doing some test swaps... ==");
 
-    swapCeloTocUSD();
-    swapcUSDtoCelo();
-    swapCeloTocEUR();
-    swapcEURtoCELO();
-    swapCeloTocBRL();
-    swapcBrlToCELO();
+    swapCeloTocUSD(config);
+    swapcUSDtoCelo(config);
+    swapCeloTocEUR(config);
+    swapcEURtoCELO(config);
+    swapCeloTocBRL(config);
+    swapcBrlToCELO(config);
     swapBridgedUSDCTocUSD(config);
     swapcUSDtoBridgedUSDC(config);
     swapBridgedUSDCTocEUR(config);
@@ -560,7 +560,7 @@ contract MU03Checks is Script, Test {
     swapcEURtoBridgedEUROC(config);
   }
 
-  function swapCeloTocUSD() internal {
+  function swapCeloTocUSD(MU03Config.MU03 memory config) internal {
     bytes32 exchangeID = BiPoolManager(biPoolManagerProxy).exchangeIds(0);
 
     address trader = vm.addr(5);
@@ -571,12 +571,19 @@ contract MU03Checks is Script, Test {
     // Give trader some celo
     vm.deal(trader, amountIn);
 
-    testAndPerformConstantProductSwap(exchangeID, trader, tokenIn, tokenOut, amountIn);
+    testAndPerformConstantProductSwap(
+      exchangeID,
+      trader,
+      tokenIn,
+      tokenOut,
+      amountIn,
+      config.cUSDCelo.referenceRateFeedID
+    );
 
     console2.log("\tCELO -> cUSD swap successful 🚀");
   }
 
-  function swapcUSDtoCelo() internal {
+  function swapcUSDtoCelo(MU03Config.MU03 memory config) internal {
     bytes32 exchangeID = BiPoolManager(biPoolManagerProxy).exchangeIds(0);
 
     address trader = vm.addr(5);
@@ -584,12 +591,19 @@ contract MU03Checks is Script, Test {
     address tokenOut = celoToken;
     uint256 amountIn = 1e18;
 
-    testAndPerformConstantProductSwap(exchangeID, trader, tokenIn, tokenOut, amountIn);
+    testAndPerformConstantProductSwap(
+      exchangeID,
+      trader,
+      tokenIn,
+      tokenOut,
+      amountIn,
+      config.cUSDCelo.referenceRateFeedID
+    );
 
     console2.log("\tcUSD -> CELO swap successful 🚀");
   }
 
-  function swapCeloTocEUR() internal {
+  function swapCeloTocEUR(MU03Config.MU03 memory config) internal {
     bytes32 exchangeID = BiPoolManager(biPoolManagerProxy).exchangeIds(1);
 
     address trader = vm.addr(5);
@@ -600,12 +614,19 @@ contract MU03Checks is Script, Test {
     // Give trader some celo
     vm.deal(trader, amountIn);
 
-    testAndPerformConstantProductSwap(exchangeID, trader, tokenIn, tokenOut, amountIn);
+    testAndPerformConstantProductSwap(
+      exchangeID,
+      trader,
+      tokenIn,
+      tokenOut,
+      amountIn,
+      config.cEURCelo.referenceRateFeedID
+    );
 
     console2.log("\tCELO -> cEUR swap successful 🚀");
   }
 
-  function swapcEURtoCELO() internal {
+  function swapcEURtoCELO(MU03Config.MU03 memory config) internal {
     bytes32 exchangeID = BiPoolManager(biPoolManagerProxy).exchangeIds(1);
 
     address trader = vm.addr(5);
@@ -613,12 +634,19 @@ contract MU03Checks is Script, Test {
     address tokenOut = celoToken;
     uint256 amountIn = 1e18;
 
-    testAndPerformConstantProductSwap(exchangeID, trader, tokenIn, tokenOut, amountIn);
+    testAndPerformConstantProductSwap(
+      exchangeID,
+      trader,
+      tokenIn,
+      tokenOut,
+      amountIn,
+      config.cEURCelo.referenceRateFeedID
+    );
 
     console2.log("\tcEUR -> CELO swap successful 🚀");
   }
 
-  function swapCeloTocBRL() internal {
+  function swapCeloTocBRL(MU03Config.MU03 memory config) internal {
     bytes32 exchangeID = BiPoolManager(biPoolManagerProxy).exchangeIds(2);
 
     address trader = vm.addr(5);
@@ -629,12 +657,19 @@ contract MU03Checks is Script, Test {
     // Give trader some celo
     vm.deal(trader, amountIn);
 
-    testAndPerformConstantProductSwap(exchangeID, trader, tokenIn, tokenOut, amountIn);
+    testAndPerformConstantProductSwap(
+      exchangeID,
+      trader,
+      tokenIn,
+      tokenOut,
+      amountIn,
+      config.cBRLCelo.referenceRateFeedID
+    );
 
     console2.log("\tCELO -> cBRL swap successful 🚀");
   }
 
-  function swapcBrlToCELO() internal {
+  function swapcBrlToCELO(MU03Config.MU03 memory config) internal {
     bytes32 exchangeID = BiPoolManager(biPoolManagerProxy).exchangeIds(2);
 
     address trader = vm.addr(5);
@@ -642,7 +677,14 @@ contract MU03Checks is Script, Test {
     address tokenOut = celoToken;
     uint256 amountIn = 1e18;
 
-    testAndPerformConstantProductSwap(exchangeID, trader, tokenIn, tokenOut, amountIn);
+    testAndPerformConstantProductSwap(
+      exchangeID,
+      trader,
+      tokenIn,
+      tokenOut,
+      amountIn,
+      config.cBRLCelo.referenceRateFeedID
+    );
 
     console2.log("\tcBRL -> CELO swap successful 🚀");
   }
@@ -658,15 +700,7 @@ contract MU03Checks is Script, Test {
     // Mint some USDC to trader
     deal(bridgedUSDC, trader, amountIn, true);
 
-    testAndPerformConstantSumSwap(
-      exchangeID,
-      trader,
-      tokenIn,
-      tokenOut,
-      amountIn,
-      config.cUSDUSDC.referenceRateFeedID,
-      true
-    );
+    testAndPerformConstantSumSwap(exchangeID, trader, tokenIn, tokenOut, amountIn, config.cUSDUSDC.referenceRateFeedID);
 
     console2.log("\tbridgedUSDC -> cUSD swap successful 🚀");
   }
@@ -682,15 +716,7 @@ contract MU03Checks is Script, Test {
     // Mint some USDC to the reserve
     deal(bridgedUSDC, reserve, 1000e18, true);
 
-    testAndPerformConstantSumSwap(
-      exchangeID,
-      trader,
-      tokenIn,
-      tokenOut,
-      amountIn,
-      config.cUSDUSDC.referenceRateFeedID,
-      false
-    );
+    testAndPerformConstantSumSwap(exchangeID, trader, tokenIn, tokenOut, amountIn, config.cUSDUSDC.referenceRateFeedID);
 
     console2.log("\tcUSD -> bridgedUSDC swap successful 🚀");
   }
@@ -706,15 +732,7 @@ contract MU03Checks is Script, Test {
     // Mint some USDC to trader
     deal(bridgedUSDC, trader, amountIn, true);
 
-    testAndPerformConstantSumSwap(
-      exchangeID,
-      trader,
-      tokenIn,
-      tokenOut,
-      amountIn,
-      config.cEURUSDC.referenceRateFeedID,
-      true
-    );
+    testAndPerformConstantSumSwap(exchangeID, trader, tokenIn, tokenOut, amountIn, config.cEURUSDC.referenceRateFeedID);
 
     console2.log("\tbridgedUSDC -> cEUR swap successful 🚀");
   }
@@ -727,15 +745,7 @@ contract MU03Checks is Script, Test {
     address tokenOut = bridgedUSDC;
     uint256 amountIn = 10e18;
 
-    testAndPerformConstantSumSwap(
-      exchangeID,
-      trader,
-      tokenIn,
-      tokenOut,
-      amountIn,
-      config.cEURUSDC.referenceRateFeedID,
-      false
-    );
+    testAndPerformConstantSumSwap(exchangeID, trader, tokenIn, tokenOut, amountIn, config.cEURUSDC.referenceRateFeedID);
 
     console2.log("\tcEUR -> bridgedUSDC swap successful 🚀");
   }
@@ -751,15 +761,7 @@ contract MU03Checks is Script, Test {
     // Mint some USDC to trader
     deal(bridgedUSDC, trader, amountIn, true);
 
-    testAndPerformConstantSumSwap(
-      exchangeID,
-      trader,
-      tokenIn,
-      tokenOut,
-      amountIn,
-      config.cBRLUSDC.referenceRateFeedID,
-      true
-    );
+    testAndPerformConstantSumSwap(exchangeID, trader, tokenIn, tokenOut, amountIn, config.cBRLUSDC.referenceRateFeedID);
 
     console2.log("\tbridgedUSDC -> cBRL swap successful 🚀");
   }
@@ -772,15 +774,7 @@ contract MU03Checks is Script, Test {
     address tokenOut = bridgedUSDC;
     uint256 amountIn = 10e18;
 
-    testAndPerformConstantSumSwap(
-      exchangeID,
-      trader,
-      tokenIn,
-      tokenOut,
-      amountIn,
-      config.cBRLUSDC.referenceRateFeedID,
-      false
-    );
+    testAndPerformConstantSumSwap(exchangeID, trader, tokenIn, tokenOut, amountIn, config.cBRLUSDC.referenceRateFeedID);
 
     console2.log("\tcBRL -> bridgedUSDC swap successful 🚀");
   }
@@ -802,8 +796,7 @@ contract MU03Checks is Script, Test {
       tokenIn,
       tokenOut,
       amountIn,
-      config.cEUREUROC.referenceRateFeedID,
-      true
+      config.cEUREUROC.referenceRateFeedID
     );
 
     console2.log("\tbridgedEUROC -> cEUR swap successful 🚀");
@@ -826,8 +819,7 @@ contract MU03Checks is Script, Test {
       tokenIn,
       tokenOut,
       amountIn,
-      config.cEUREUROC.referenceRateFeedID,
-      false
+      config.cEUREUROC.referenceRateFeedID
     );
 
     console2.log("\tcEUR -> bridgedEUROC swap successful 🚀");
@@ -874,28 +866,29 @@ contract MU03Checks is Script, Test {
     address trader,
     address tokenIn,
     address tokenOut,
-    uint256 amountIn
+    uint256 amountIn,
+    address rateFeedID
   ) internal {
     uint256 amountOut = Broker(brokerProxy).getAmountOut(biPoolManagerProxy, exchangeID, tokenIn, tokenOut, amountIn);
     IBiPoolManager.PoolExchange memory pool = BiPoolManager(biPoolManagerProxy).getPoolExchange(exchangeID);
+    (uint256 numerator, uint256 denominator) = SortedOracles(sortedOraclesProxy).medianRate(rateFeedID);
+    FixidityLib.Fraction memory rate = FixidityLib.newFixedFraction(numerator, denominator);
 
-    FixidityLib.Fraction memory numerator;
-    FixidityLib.Fraction memory denominator;
+    FixidityLib.Fraction memory netAmountIn = FixidityLib.newFixed(amountIn).multiply(
+      FixidityLib.newFixedFraction(9975, 10000)
+    );
 
+    uint256 estimatedAmountOut;
     if (tokenIn == pool.asset0) {
-      numerator = FixidityLib.newFixed(amountIn).multiply(FixidityLib.newFixed(pool.bucket1));
-      denominator = FixidityLib.newFixed(pool.bucket0).add(FixidityLib.newFixed(amountIn));
+      estimatedAmountOut = netAmountIn.divide(rate).fromFixed();
     } else {
-      numerator = FixidityLib.newFixed(amountIn).multiply(FixidityLib.newFixed(pool.bucket0));
-      denominator = FixidityLib.newFixed(pool.bucket1).add(FixidityLib.newFixed(amountIn));
+      estimatedAmountOut = netAmountIn.multiply(rate).fromFixed();
     }
-
-    uint256 estimatedAmountOut = numerator.unwrap().div(denominator.unwrap());
 
     FixidityLib.Fraction memory maxTolerance = FixidityLib.newFixedFraction(25, 10000);
     uint256 threshold = FixidityLib.newFixed(estimatedAmountOut).multiply(maxTolerance).fromFixed();
-    assertApproxEqAbs(amountOut, estimatedAmountOut, threshold);
 
+    assertApproxEqAbs(amountOut, estimatedAmountOut, threshold);
     doSwapIn(exchangeID, trader, tokenIn, tokenOut, amountIn, amountOut);
   }
 
@@ -905,30 +898,25 @@ contract MU03Checks is Script, Test {
     address tokenIn,
     address tokenOut,
     uint256 amountIn,
-    address rateFeedID,
-    bool isBridgedUsdcToStable
+    address rateFeedID
   ) internal {
     uint256 amountOut = Broker(brokerProxy).getAmountOut(biPoolManagerProxy, exchangeID, tokenIn, tokenOut, amountIn);
+    IBiPoolManager.PoolExchange memory pool = BiPoolManager(biPoolManagerProxy).getPoolExchange(exchangeID);
     (uint256 numerator, uint256 denominator) = SortedOracles(sortedOraclesProxy).medianRate(rateFeedID);
-    uint256 estimatedAmountOut;
+    FixidityLib.Fraction memory rate = FixidityLib.newFixedFraction(numerator, denominator);
 
-    if (isBridgedUsdcToStable) {
-      estimatedAmountOut = FixidityLib
-        .newFixed(amountIn.mul(1e12))
-        .multiply(FixidityLib.wrap(numerator).divide(FixidityLib.wrap(denominator)))
-        .fromFixed();
-    } else {
-      estimatedAmountOut = FixidityLib
-        .newFixed(amountIn)
-        .multiply(FixidityLib.wrap(denominator).divide(FixidityLib.wrap(numerator)))
-        .fromFixed();
+    uint256 estimatedAmountOut;
+    if (tokenIn == pool.asset0) {
+      estimatedAmountOut = FixidityLib.newFixed(amountIn).divide(rate).fromFixed();
       estimatedAmountOut = estimatedAmountOut.div(1e12);
+    } else {
+      estimatedAmountOut = FixidityLib.newFixed(amountIn.mul(1e12)).multiply(rate).fromFixed();
     }
 
     FixidityLib.Fraction memory maxTolerance = FixidityLib.newFixedFraction(25, 1000);
     uint256 threshold = FixidityLib.newFixed(estimatedAmountOut).multiply(maxTolerance).fromFixed();
-    assertApproxEqAbs(amountOut, estimatedAmountOut, threshold);
 
+    assertApproxEqAbs(amountOut, estimatedAmountOut, threshold);
     doSwapIn(exchangeID, trader, tokenIn, tokenOut, amountIn, amountOut);
   }
 

--- a/script/upgrades/MU03/MU03Checks.sol
+++ b/script/upgrades/MU03/MU03Checks.sol
@@ -108,7 +108,6 @@ contract MU03Checks is Script, Test {
     setUp();
 
     verifyOwner();
-    //verifyExchangeLength();
     verifyEUROCSetUp();
     verifyBiPoolManager();
     verifySortedOracles();
@@ -135,19 +134,6 @@ contract MU03Checks is Script, Test {
     );
     require(Broker(broker).owner() == governance, "Broker ownership not transferred to governance");
     console2.log("Contract ownerships transferred to governance 🤝");
-  }
-
-  function verifyExchangeLength() internal view {
-    bytes32[] memory exchanges = BiPoolManager(biPoolManagerProxy).getExchangeIds();
-    if (exchanges.length != 4) {
-      console2.log(
-        "The number of expected exchanges: %s does not match the number of deployed exchanges: %s.",
-        4,
-        exchanges.length
-      );
-      revert("Number of expected exchanges does not match the number of deployed exchanges. See logs.");
-    }
-    console2.log("\tNumber of exchanges matches the expected number of exchanges 🤘🏼");
   }
 
   function verifyEUROCSetUp() internal view {


### PR DESCRIPTION
### Description
- this Pr removes the destruction and recreation of all pools and only destroys the cUSD/USDC pool since that one actually needs to be destroyed and recreated. 
- also it changes the way constant product pair swaps are tested. The Calculation from now on uses the current median rate instead of the buckets as these can be largely outdated and cause failing tests. 

### Other changes

- reordered the implementation updates to represent the call order

### Tested

- simulation is green 

### Related issues

- Fixes #[issue number here]

### Backwards compatibility


### Documentation


