### PR TITLE
fix: remove unnecessary Value Delta Breaker transactions

### DIFF
--- a/script/upgrades/MU03/MU03.sol
+++ b/script/upgrades/MU03/MU03.sol
@@ -499,47 +499,41 @@ contract MU03 is IMentoUpgrade, GovernanceScript {
   }
 
   function proposal_configureValueDeltaBreaker0(MU03Config.MU03 memory config) public {
-    // Set reference value for USDC/USD, EUROC/EUR rate Feed
+    // Set reference value for EUROC/EUR rate feed
     transactions.push(
       ICeloGovernance.Transaction(
         0,
         valueDeltaBreaker,
         abi.encodeWithSelector(
           ValueDeltaBreaker(0).setReferenceValues.selector,
-          Arrays.addresses(config.USDCUSD.rateFeedID, config.EUROCEUR.rateFeedID),
-          Arrays.uints(
-            config.USDCUSD.valueDeltaBreaker0.referenceValue,
-            config.EUROCEUR.valueDeltaBreaker0.referenceValue
-          )
+          Arrays.addresses(config.EUROCEUR.rateFeedID),
+          Arrays.uints(config.EUROCEUR.valueDeltaBreaker0.referenceValue)
         )
       )
     );
 
-    // Set cooldown time for USDC/USD, EUROC/EUR rate Feeds
+    // Set cooldown time for EUROC/EUR rate feed
     transactions.push(
       ICeloGovernance.Transaction(
         0,
         valueDeltaBreaker,
         abi.encodeWithSelector(
           ValueDeltaBreaker(0).setCooldownTimes.selector,
-          Arrays.addresses(config.USDCUSD.rateFeedID, config.EUROCEUR.rateFeedID),
-          Arrays.uints(config.USDCUSD.valueDeltaBreaker0.cooldown, config.EUROCEUR.valueDeltaBreaker0.cooldown)
+          Arrays.addresses(config.EUROCEUR.rateFeedID),
+          Arrays.uints(config.EUROCEUR.valueDeltaBreaker0.cooldown)
         )
       )
     );
 
-    /// Set rate change thresholds for USDC/USD, EUROC/EUR rate Feeds
+    /// Set rate change threshold for EUROC/EUR rate feed
     transactions.push(
       ICeloGovernance.Transaction(
         0,
         valueDeltaBreaker,
         abi.encodeWithSelector(
           ValueDeltaBreaker(0).setRateChangeThresholds.selector,
-          Arrays.addresses(config.USDCUSD.rateFeedID, config.EUROCEUR.rateFeedID),
-          Arrays.uints(
-            config.USDCUSD.valueDeltaBreaker0.threshold.unwrap(),
-            config.EUROCEUR.valueDeltaBreaker0.threshold.unwrap()
-          )
+          Arrays.addresses(config.EUROCEUR.rateFeedID),
+          Arrays.uints(config.EUROCEUR.valueDeltaBreaker0.threshold.unwrap())
         )
       )
     );


### PR DESCRIPTION
### Description
- Since the ValueDeltaBreaker hasn't changed in MU03 and the breaking logic is already set for USDC/USD there is no need for setting it again. We only need to configure the breaker for the new EUROC/EUR rate.

### Other changes



### Tested

- The values on mainnet for the USDC/USD rate feed are equal to the once in the config. 
- I ran an isolated simulation on baklava with only the valueDeltaBreaker part + the checks  
- also we are going to run the whole script on alfajores where the state is more simular to mainnet 

### Related issues

- Fixes #109 

### Backwards compatibility

- the configuration already is configured with the same values

### Documentation

