### PR TITLE
feat: set spending ratio for EUROC

### DIFF
--- a/script/upgrades/MU03/MU03Checks.sol
+++ b/script/upgrades/MU03/MU03Checks.sol
@@ -144,6 +144,11 @@ contract MU03Checks is Script, Test {
       console2.log("EUROC is not a collateral asset 🏦");
       revert("EUROC is not a collateral asset");
     }
+    if (partialReserve.getDailySpendingRatioForCollateralAsset(bridgedEUROC) != FixidityLib.fixed1().unwrap()) {
+      revert("EUROC daily spending ratio not set correctly");
+    } else {
+      console2.log("EUROC daily spending ratio set correctly 🏦");
+    }
   }
 
   function verifyBiPoolManager() internal view {


### PR DESCRIPTION
### Description

we forgot to set the `Daily Spending Ratio For Collateral Asset` for Euroc. This PR adds the needed transaction plus the check. I also  ran the script on baklava 
![image](https://github.com/mento-protocol/mento-deployment/assets/80156619/b6118362-07e9-414e-8e93-d9145870703f)


### Other changes



### Tested

- ran the simulation 
- ran the script + checks 
- verified the value afterward 


### Related issues



### Backwards compatibility



### Documentation


