### PR TITLE
test: add eXOF initialization parameters check

### DIFF
--- a/script/upgrades/eXOF/eXOFChecks.verify.sol
+++ b/script/upgrades/eXOF/eXOFChecks.verify.sol
@@ -65,7 +65,7 @@ contract eXOFChecksVerify is eXOFChecksBase {
   function verifyToken(eXOFConfig.eXOF memory config) internal {
     console.log("\n== Verifying Token Transactions ==");
     verifyOwner();
-    verifyEXOFStableToken();
+    verifyEXOFStableToken(config);
     verifyConstitution(config);
     verifyEXOFAddedToReserve();
     verifyEXOFAddedToFeeCurrencyWhitelist();
@@ -83,7 +83,7 @@ contract eXOFChecksVerify is eXOFChecksBase {
     console.log("🟢 Contract ownerships transferred to governance");
   }
 
-  function verifyEXOFStableToken() internal view {
+  function verifyEXOFStableToken(eXOFConfig.eXOF memory config) internal {
     StableTokenXOFProxy stableTokenXOFProxy = StableTokenXOFProxy(eXOF);
     address eXOFDeployedImplementation = contracts.deployed("StableTokenXOF");
 
@@ -97,6 +97,34 @@ contract eXOFChecksVerify is eXOFChecksBase {
       revert("Deployed StableTokenXOF does not match what proxy points to. See logs.");
     }
     console.log("🟢 StableTokenXOFProxy has the correct implementation address");
+
+    // ----- verify initialization parameters -----
+    StableTokenXOF eXOFToken = StableTokenXOF(eXOF);
+
+    assertEq(eXOFToken.name(), config.stableTokenXOF.name, "❗️❌ eXOF name not set correctly!");
+    assertEq(eXOFToken.symbol(), config.stableTokenXOF.symbol, "❗️❌ eXOF symbol not set correctly!");
+    assertEq(
+      uint(eXOFToken.decimals()),
+      uint(config.stableTokenXOF.decimals),
+      "❗️❌ eXOF decimals not set correctly!"
+    );
+    assertEq(
+      eXOFToken.getExchangeRegistryId(),
+      keccak256(abi.encodePacked(config.stableTokenXOF.exchangeIdentifier)),
+      "❗️❌ eXOF exchange registry id not set correctly!"
+    );
+
+    // inflation parameters
+    (uint256 actualInflationRate, , uint256 actualInflationPeriod, ) = eXOFToken.getInflationParameters();
+    assertEq(actualInflationRate, config.stableTokenXOF.inflationRate, "❗️❌ eXOF inflation rate not set correctly!");
+    assertEq(
+      actualInflationPeriod,
+      config.stableTokenXOF.inflationFactorUpdatePeriod,
+      "❗️❌ eXOF inflation period not set correctly!"
+    );
+
+    // no pre-mint
+    assertEq(eXOFToken.totalSupply(), 0, "❗️❌ eXOF pre-minted tokens!");
   }
 
   function verifyEXOFAddedToReserve() internal view {


### PR DESCRIPTION
### Description

Added a few checks which I noticed were missing for the initialization parameters of the token. Didn't bother to get them to throw upon mismatch as I was mainly interested to ensure that things like name, symbol, etc were correctly set.

### Tested

- Ran the simulation on Alfajores without any assertion logs
```
Starting eXOF checks:

==  Rate feeds ==
     EUROCXOF: 0xeD35e46b095197dA30DdFFA5B91d386886d5ce0d
     EURXOF: 0x40dC8528167557353fdcD98548AB2139A670Dd0b
     CELOXOF: 0xB0FA15e002516d0301884059c0aaC0F0C72b019D

== Verifying Token Transactions ==
  🟢 Contract ownerships transferred to governance
  🟢 StableTokenXOFProxy has the correct implementation address
  🟢 Constitution params configured correctly
  🟢 eXOF has been added to the reserve
  🟢 eXOF has been added to the fee currency whitelist

== Verifying exchanges ==
  🟢 PoolExchange correctly configured 🤘🏼
  🟢 Pool config is correctly configured 🤘🏼
  🟢 Trading limits set for all exchanges 🔒

== Checking circuit breaker ==
  🟢 Rate feed dependencies configured correctly 🗳️
  🟢 Breakers enabled for all rate feeds 🗳️
  🟢 MedianDeltaBreaker cooldown, rate change threshold and smoothing factor set correctly 🔒
  🟢 ValueDeltaBreaker cooldown, rate change threshold and reference value set correctly 🔒

== Starting eXOF test swaps: ==
  EUROCXOF tradingMode:  0
  CELOXOF tradingMode:  0
  EURXOF tradingMode:  0
  🟢 CELO -> eXOF swap successful 🚀
  🟢 eXOF -> CELO swap successful 🚀
  🟢 bridgedEUROC -> eXOF swap successful 🚀
  🟢 eXOF -> bridgedEUROC swap successful 🚀
✨  Done in 36.55s.
```
