### PR TITLE
fix: remove isCollateralAsset check in MU04

### DIFF
--- a/script/upgrades/MU04/MU04.sol
+++ b/script/upgrades/MU04/MU04.sol
@@ -293,15 +293,13 @@ contract MU04 is IMentoUpgrade, GovernanceScript {
     uint[] memory spendingRatios = Arrays.uints(1e24 * 0.2, 1e24, 1e24);
 
     for (uint i = 0; i < collateralAssets.length; i++) {
-      if (!Reserve(reserveProxy).isCollateralAsset(collateralAssets[i])) {
-        transactions.push(
-          ICeloGovernance.Transaction(
-            0,
-            reserveProxy,
-            abi.encodeWithSelector(Reserve(0).addCollateralAsset.selector, collateralAssets[i])
-          )
-        );
-      }
+      transactions.push(
+        ICeloGovernance.Transaction(
+          0,
+          reserveProxy,
+          abi.encodeWithSelector(Reserve(0).addCollateralAsset.selector, collateralAssets[i])
+        )
+      );
     }
 
     transactions.push(


### PR DESCRIPTION
### Description

While simulating MU04 on Alfajores we ran into a revert which was caused due to calling `isCollateralAsset` on `ReserveProxy` that is still pointing to the legacy implementation. Our speculation is that the reason this worked on Baklava is that at some point we upgraded the implementation of the legacy reserve contract to the new one outside of MU04.

### Tested

Simulation now works on Alfajores ✅
