### PR TITLE
feat: increase cEUR/EUROC trading limits

### DIFF
--- a/script/upgrades/MU04/Config.sol
+++ b/script/upgrades/MU04/Config.sol
@@ -222,10 +222,10 @@ library MU04Config {
       asset0limits: Config.TradingLimit({
         enabled0: true,
         timeStep0: 5 minutes,
-        limit0: 500_000,
+        limit0: 2_500_000,
         enabled1: true,
         timeStep1: 1 days,
-        limit1: 1_000_000,
+        limit1: 5_000_000,
         enabledGlobal: false,
         limitGlobal: 0
       }),


### PR DESCRIPTION
### Description

This PR adds the final changes to the MU04 config. It further increases the trading limits for the cEUR/EUROC pair.

### Other changes
- n/a


### Tested

parameters come from @sissnad and @rcroessmann 

### Related issues

https://github.com/mento-protocol/mento-core/issues/310

### Backwards compatibility

- n/a

### Documentation

- n/a
