### PR TITLE
chore: add link to proposal markdown

### DIFF
--- a/script/upgrades/MU04/MU04.sol
+++ b/script/upgrades/MU04/MU04.sol
@@ -137,7 +137,7 @@ contract MU04 is IMentoUpgrade, GovernanceScript {
 
     vm.startBroadcast(Chain.deployerPrivateKey());
     {
-      createProposal(_transactions, "MU04", governance);
+      createProposal(_transactions, "https://github.com/celo-org/governance/blob/main/CGPs/cgp-0109.md", governance);
     }
     vm.stopBroadcast();
   }


### PR DESCRIPTION
### Description

this Pr adds the link to the proposal markdown in the celo governance repo.

### Other changes

- n/a

### Tested

n/a

### Related issues

- n/a

### Backwards compatibility

- n/a

### Documentation

- n/a
