### PR TITLE
Fix for get-secrets.sh: added macOS-compatible path for `sed` util usage

### DIFF
--- a/bin/get-secrets.sh
+++ b/bin/get-secrets.sh
@@ -2,7 +2,7 @@
 
 ##############################################################################
 # Script for pulling secret keys from GCP secret manager.
-# Usage: ./bin/get-secrets.sh 
+# Usage: ./bin/get-secrets.sh
 ##############################################################################
 
 # Authenticate with Google Cloud
@@ -23,17 +23,23 @@ for SECRET_ID in $(echo "$SECRET_IDS" | tr ',' ' '); do
   SECRET_VALUE="$(gcloud secrets versions access latest --secret="$SECRET_ID" --project="$PROJECT_ID")"
 
   # Write the secret value to the .env file
-  
-  # If the secret name already exists in the .env file, replace the value with the new value. 
+
+  # If the secret name already exists in the .env file, replace the value with the new value.
   if grep -q "^$SECRET_NAME=" "$ENV_FILE"; then
-    sed -i "s/^$SECRET_NAME=.*/$SECRET_NAME=$SECRET_VALUE/g" "$ENV_FILE"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+      # macOS sed syntax
+      sed -i "" "s/^$SECRET_NAME=.*/$SECRET_NAME=$SECRET_VALUE/g" "$ENV_FILE"
+    else
+      # GNU/Linux sed syntax
+      sed -i "s/^$SECRET_NAME=.*/$SECRET_NAME=$SECRET_VALUE/g" "$ENV_FILE"
+    fi
   else
     # If the .env file is not empty, append the secret name and value to the .env file.
     if [[ -s "$ENV_FILE" ]]; then
-      printf "\n%s=%s" "$SECRET_NAME" "$SECRET_VALUE" >> "$ENV_FILE"
+      printf "\n%s=%s" "$SECRET_NAME" "$SECRET_VALUE" >>"$ENV_FILE"
     else
       # If we don't have an .env, write the secret name and value to the .env file.
-      echo -n "$SECRET_NAME=$SECRET_VALUE" >> "$ENV_FILE"
+      echo -n "$SECRET_NAME=$SECRET_VALUE" >>"$ENV_FILE"
     fi
   fi
 done


### PR DESCRIPTION
`yarn secrets:get` errored on my machine with a shell syntax error on the `sed` usage which slightly differs between linux and macOS environments

This PR adds a macOS-specific version of this command (if runtime env is macOS, else nothing changes)

On the `main` branch, running `yarn secrets:get` threw an error:

```
$ ./bin/get-secrets.sh ./bin/../.env sed: 1: "./bin/../.env": invalid command code . sed: 1: "./bin/../.env": invalid command code . sed: 1: "./bin/../.env": invalid command code . error Command failed with exit code 1.
```

Copilot had this to say on the matter which made sense and the syntax change works for me locally:

<img width="754" alt="image" src="https://github.com/mento-protocol/mento-deployment/assets/117495/5e554df3-31b7-426c-89d6-7d6a16fb2533">
