### PR TITLE
Fix/use multisig as reserve safety fund address

### DIFF
--- a/script/upgrades/MUGOV/MUGOV.sol
+++ b/script/upgrades/MUGOV/MUGOV.sol
@@ -80,7 +80,7 @@ contract MUGOV is IMentoUpgrade, GovernanceScript {
       contracts.dependency("MentoLabsMultisig"), // #2, Mento Labs Team. @TODO: Update final recipient in deps.json
       contracts.dependency("MentoLiquiditySupport"), // #3, Liquidity Support. @TODO: Update final recipient in deps.json
       contracts.dependency("CeloCommunityTreasury"), // #5, Celo Community Treasury. @TODO: Update final recipient in deps.json
-      contracts.celoRegistry("Reserve") // #6, Reserve Safety Fund.
+      contracts.dependency("PartialReserveMultisig") // #6, Reserve Safety Fund.
     );
     params.additionalAllocationAmounts = Arrays.uints(300, 100, 50, 50);
 

--- a/script/upgrades/MUGOV/MUGOVChecks.sol
+++ b/script/upgrades/MUGOV/MUGOVChecks.sol
@@ -49,7 +49,7 @@ contract MUGOVChecks is GovernanceScript, Test {
     mentoLabsMultisig = contracts.dependency("MentoLabsMultisig");
     mentoLiquiditySupport = contracts.dependency("MentoLiquiditySupport");
     celoCommunityTreasury = contracts.dependency("CeloCommunityTreasury");
-    reserve = contracts.celoRegistry("Reserve");
+    reserve = contracts.dependency("PartialReserveMultisig");
     watchdogMultisig = contracts.dependency("WatchdogMultisig");
     fractalSigner = contracts.dependency("FractalSigner");
   }


### PR DESCRIPTION
### Description

Update MUGOV so the reserve safety allocation goes to the reserve multisig instead of the on-chain reserve

### Other changes

No

### Related issue

- Fixes #181 

### How to review

Verify that the reserve safety allocation goes to the reserve multisig address on mainnet: 0x87647780180B8f55980C7D3fFeFe08a9B29e9aE1
