### PR TITLE
feat: add mentolabs and celo treasury addresses

### DIFF
--- a/script/upgrades/MUGOV/MUGOV.sol
+++ b/script/upgrades/MUGOV/MUGOV.sol
@@ -77,9 +77,9 @@ contract MUGOV is IMentoUpgrade, GovernanceScript {
     IGovernanceFactory.MentoTokenAllocationParams memory params;
 
     params.additionalAllocationRecipients = Arrays.addresses(
-      contracts.dependency("MentoLabsMultisig"), // #2, Mento Labs Team. @TODO: Update final recipient in deps.json
+      contracts.dependency("MentoLabsMultisig"), // #2, Mento Labs Team.
       contracts.dependency("MentoLiquiditySupport"), // #3, Liquidity Support. @TODO: Update final recipient in deps.json
-      contracts.dependency("CeloCommunityTreasury"), // #5, Celo Community Treasury. @TODO: Update final recipient in deps.json
+      contracts.celoRegistry("Governance"), // #5, Celo Community Treasury.
       contracts.dependency("PartialReserveMultisig") // #6, Reserve Safety Fund.
     );
     params.additionalAllocationAmounts = Arrays.uints(300, 100, 50, 50);

--- a/script/upgrades/MUGOV/MUGOVChecks.sol
+++ b/script/upgrades/MUGOV/MUGOVChecks.sol
@@ -48,7 +48,7 @@ contract MUGOVChecks is GovernanceScript, Test {
 
     mentoLabsMultisig = contracts.dependency("MentoLabsMultisig");
     mentoLiquiditySupport = contracts.dependency("MentoLiquiditySupport");
-    celoCommunityTreasury = contracts.dependency("CeloCommunityTreasury");
+    celoCommunityTreasury = contracts.celoRegistry("Governance");
     reserve = contracts.dependency("PartialReserveMultisig");
     watchdogMultisig = contracts.dependency("WatchdogMultisig");
     fractalSigner = contracts.dependency("FractalSigner");

--- a/script/upgrades/dependencies.json
+++ b/script/upgrades/dependencies.json
@@ -13,7 +13,8 @@
     "ExchangeEUR": "0xe383394b913d7302c49f794c7d3243c429d53d1d",
     "ExchangeBRL": "0x8f2cf9855c919afac8bd2e7acec0205ed568a4ea",
     "GrandaMento": "0x03f6842b82dd2c9276931a17dd23d73c16454a49",
-    "MentoLabsMultisig": "0x",
+    "MentoLabsMultisig": "0x655133d8E90F8190ed5c1F0f3710F602800C0150",
+    "MentoLiquiditySupport": "0x",
     "WatchdogMultisig": "0x",
     "FractalSigner": "0xacD08d6714ADba531beFF582e6FD5DA1AFD6bc65"
   },


### PR DESCRIPTION
### Description

Adds missing Mento Labs multisig address 0x655133d8E90F8190ed5c1F0f3710F602800C0150 to the mainnet dependencies
Fetches the Celo community treasury address from registry
Fixes post deployment checks

### Other changes

adds missing TBD variable for the MentoLiquiditySupport to the mainnet dependencies


### Related issues

- Fixes #182 
