### PR TITLE
Feat/watchdog and liqco addresses

### DIFF
--- a/script/upgrades/MUGOV/MUGOV.sol
+++ b/script/upgrades/MUGOV/MUGOV.sol
@@ -54,7 +54,7 @@ contract MUGOV is IMentoUpgrade, GovernanceScript {
         mentoGovernanceFactory,
         abi.encodeWithSelector(
           IGovernanceFactory(0).createGovernance.selector,
-          contracts.dependency("WatchdogMultisig"), // @TODO: Update final address in deps.json
+          contracts.dependency("WatchdogMultisig"),
           readAirgrabMerkleRoot(), // @TODO: Update merkle tree after final snapshot
           contracts.dependency("FractalSigner"),
           allocationParams
@@ -78,7 +78,7 @@ contract MUGOV is IMentoUpgrade, GovernanceScript {
 
     params.additionalAllocationRecipients = Arrays.addresses(
       contracts.dependency("MentoLabsMultisig"), // #2, Mento Labs Team.
-      contracts.dependency("MentoLiquiditySupport"), // #3, Liquidity Support. @TODO: Update final recipient in deps.json
+      contracts.dependency("MentoLiquiditySupport"), // #3, Liquidity Support.
       contracts.celoRegistry("Governance"), // #5, Celo Community Treasury.
       contracts.dependency("PartialReserveMultisig") // #6, Reserve Safety Fund.
     );

--- a/script/upgrades/MUGOV/MUGOV.sol
+++ b/script/upgrades/MUGOV/MUGOV.sol
@@ -79,7 +79,7 @@ contract MUGOV is IMentoUpgrade, GovernanceScript {
     params.additionalAllocationRecipients = Arrays.addresses(
       contracts.dependency("MentoLabsMultisig"), // #2, Mento Labs Team.
       contracts.dependency("MentoLiquiditySupport"), // #3, Liquidity Support.
-      contracts.celoRegistry("Governance"), // #5, Celo Community Treasury.
+      contracts.celoRegistry("Governance"), // #5, Celo Community Treasury. // TODO: Update this to the correct address
       contracts.dependency("PartialReserveMultisig") // #6, Reserve Safety Fund.
     );
     params.additionalAllocationAmounts = Arrays.uints(300, 100, 50, 50);

--- a/script/upgrades/MUGOV/MUGOV.sol
+++ b/script/upgrades/MUGOV/MUGOV.sol
@@ -77,9 +77,9 @@ contract MUGOV is IMentoUpgrade, GovernanceScript {
     IGovernanceFactory.MentoTokenAllocationParams memory params;
 
     params.additionalAllocationRecipients = Arrays.addresses(
-      contracts.dependency("MentoLabsMultisig"), // #2, Mento Labs Team. @TODO: Update final recipient in deps.json
+      contracts.dependency("MentoLabsMultisig"), // #2, Mento Labs Team.
       contracts.dependency("MentoLiquiditySupport"), // #3, Liquidity Support. @TODO: Update final recipient in deps.json
-      contracts.dependency("CeloCommunityTreasury"), // #5, Celo Community Treasury. @TODO: Update final recipient in deps.json
+      contracts.celoRegistry("Governance"), // #5, Celo Community Treasury.
       contracts.dependency("PartialReserveMultisig") // #6, Reserve Safety Fund.
     );
     params.additionalAllocationAmounts = Arrays.uints(300, 100, 50, 50);

--- a/script/upgrades/MUGOV/MUGOVChecks.sol
+++ b/script/upgrades/MUGOV/MUGOVChecks.sol
@@ -48,7 +48,7 @@ contract MUGOVChecks is GovernanceScript, Test {
 
     mentoLabsMultisig = contracts.dependency("MentoLabsMultisig");
     mentoLiquiditySupport = contracts.dependency("MentoLiquiditySupport");
-    celoCommunityTreasury = contracts.dependency("CeloCommunityTreasury");
+    celoCommunityTreasury = contracts.celoRegistry("Governance");
     reserve = contracts.dependency("PartialReserveMultisig");
     watchdogMultisig = contracts.dependency("WatchdogMultisig");
     fractalSigner = contracts.dependency("FractalSigner");

--- a/script/upgrades/dependencies.json
+++ b/script/upgrades/dependencies.json
@@ -14,8 +14,8 @@
     "ExchangeBRL": "0x8f2cf9855c919afac8bd2e7acec0205ed568a4ea",
     "GrandaMento": "0x03f6842b82dd2c9276931a17dd23d73c16454a49",
     "MentoLabsMultisig": "0x655133d8E90F8190ed5c1F0f3710F602800C0150",
-    "MentoLiquiditySupport": "0x",
-    "WatchdogMultisig": "0x",
+    "MentoLiquiditySupport": "0xA74Ac93de1A209957E62391B01E09161277a9ffC",
+    "WatchdogMultisig": "0xE6951C4176aaB41097C6f5fE11e9c515B7108acd",
     "FractalSigner": "0xacD08d6714ADba531beFF582e6FD5DA1AFD6bc65"
   },
   "62320": {

--- a/script/upgrades/dependencies.json
+++ b/script/upgrades/dependencies.json
@@ -13,7 +13,8 @@
     "ExchangeEUR": "0xe383394b913d7302c49f794c7d3243c429d53d1d",
     "ExchangeBRL": "0x8f2cf9855c919afac8bd2e7acec0205ed568a4ea",
     "GrandaMento": "0x03f6842b82dd2c9276931a17dd23d73c16454a49",
-    "MentoLabsMultisig": "0x",
+    "MentoLabsMultisig": "0x655133d8E90F8190ed5c1F0f3710F602800C0150",
+    "MentoLiquiditySupport": "0x",
     "WatchdogMultisig": "0x",
     "FractalSigner": "0xacD08d6714ADba531beFF582e6FD5DA1AFD6bc65"
   },


### PR DESCRIPTION
### Description

Adds missing watchdog and liq sup addresses to the dependencies.

<img width="854" alt="image" src="https://github.com/mento-protocol/mento-deployment/assets/17413894/d9858b3e-342e-479b-bb54-1fab9448f0cb">


### Other changes

Adds a TODO for the missing Celo community address


### Related issues

- Fixes #186 
