### PR TITLE
Feat/foundation address for celo allocation

### DIFF
--- a/script/upgrades/MUGOV/MUGOV.sol
+++ b/script/upgrades/MUGOV/MUGOV.sol
@@ -55,7 +55,7 @@ contract MUGOV is IMentoUpgrade, GovernanceScript {
         abi.encodeWithSelector(
           IGovernanceFactory(0).createGovernance.selector,
           contracts.dependency("WatchdogMultisig"),
-          readAirgrabMerkleRoot(), // @TODO: Update merkle tree after final snapshot
+          readAirgrabMerkleRoot(),
           contracts.dependency("FractalSigner"),
           allocationParams
         )
@@ -79,7 +79,7 @@ contract MUGOV is IMentoUpgrade, GovernanceScript {
     params.additionalAllocationRecipients = Arrays.addresses(
       contracts.dependency("MentoLabsMultisig"), // #2, Mento Labs Team.
       contracts.dependency("MentoLiquiditySupport"), // #3, Liquidity Support.
-      contracts.celoRegistry("Governance"), // #5, Celo Community Treasury. // TODO: Update this to the correct address
+      contracts.dependency("MentoFoundationMultisig"), // #5, Celo Community Allocation initially goes to the Foundation Multisig.
       contracts.dependency("PartialReserveMultisig") // #6, Reserve Safety Fund.
     );
     params.additionalAllocationAmounts = Arrays.uints(300, 100, 50, 50);

--- a/script/upgrades/MUGOV/MUGOVChecks.sol
+++ b/script/upgrades/MUGOV/MUGOVChecks.sol
@@ -22,7 +22,7 @@ contract MUGOVChecks is GovernanceScript, Test {
 
   address mentoLabsMultisig;
   address mentoLiquiditySupport;
-  address celoCommunityTreasury;
+  address foundationMultisig;
   address reserve;
   address watchdogMultisig;
   address fractalSigner;
@@ -48,7 +48,7 @@ contract MUGOVChecks is GovernanceScript, Test {
 
     mentoLabsMultisig = contracts.dependency("MentoLabsMultisig");
     mentoLiquiditySupport = contracts.dependency("MentoLiquiditySupport");
-    celoCommunityTreasury = contracts.celoRegistry("Governance");
+    foundationMultisig = contracts.dependency("MentoFoundationMultisig");
     reserve = contracts.dependency("PartialReserveMultisig");
     watchdogMultisig = contracts.dependency("WatchdogMultisig");
     fractalSigner = contracts.dependency("FractalSigner");
@@ -60,7 +60,7 @@ contract MUGOVChecks is GovernanceScript, Test {
     // ============== Token allocation ==============
     assertEq(mentoToken.balanceOf(mentoLabsMultisig), 300_000_000 * 1e18, "❌ mentoLabsMultisig allocation");
     assertEq(mentoToken.balanceOf(mentoLiquiditySupport), 100_000_000 * 1e18, "❌ mentoLiquiditySupport allocation");
-    assertEq(mentoToken.balanceOf(celoCommunityTreasury), 50_000_000 * 1e18, "❌ celoCommunityTreasury allocation");
+    assertEq(mentoToken.balanceOf(foundationMultisig), 50_000_000 * 1e18, "❌ celoCommunityTreasury allocation");
     assertEq(mentoToken.balanceOf(reserve), 50_000_000 * 1e18, "❌ reserve allocation");
     assertEq(mentoToken.balanceOf(address(airgrab)), 50_000_000 * 1e18, "❌ airgrab allocation");
     assertEq(mentoToken.balanceOf(address(governanceTimelock)), 50_000_000 * 1e18, "❌ governanceTimelock allocation");

--- a/script/upgrades/dependencies.json
+++ b/script/upgrades/dependencies.json
@@ -51,7 +51,7 @@
     "ExchangeEUR": "0x997b494f17d3c49e66fafb50f37a972d8db9325b",
     "ExchangeBRL": "0xf391dcaf77360d39e566b93c8c0ceb7128fa1a08",
     "GrandaMento": "0xecf09fcd57b0c8b1fd3de92d59e234b88938485b",
-    "MentoLabsMultisig": "0x56fD3F2bEE130e9867942D0F463a16fBE49B8d81",
+    "MentoLabsMultisig": "0xd968896991d5903613E9A83587FfFc7c8a046ffe",
     "WatchdogMultisig": "0x823655c966be3b6344Efd4D2A0FE8d0a1e3D691B",
     "MentoFoundationMultisig": "0x707D2B6Bd0acf76821AD5A09A1C6F43d6d6f692c",
     "MentoLiquiditySupport": "0x6bD481a12cb2790E7EE805b9E6e7E91917DeEe6a",

--- a/script/upgrades/dependencies.json
+++ b/script/upgrades/dependencies.json
@@ -16,7 +16,8 @@
     "MentoLabsMultisig": "0x655133d8E90F8190ed5c1F0f3710F602800C0150",
     "MentoLiquiditySupport": "0xA74Ac93de1A209957E62391B01E09161277a9ffC",
     "WatchdogMultisig": "0xE6951C4176aaB41097C6f5fE11e9c515B7108acd",
-    "FractalSigner": "0xacD08d6714ADba531beFF582e6FD5DA1AFD6bc65"
+    "FractalSigner": "0xacD08d6714ADba531beFF582e6FD5DA1AFD6bc65",
+    "MentoFoundationMultisig": "0x3468D23A0B1aB3Ab9A537813166A8f7ff1947014"
   },
   "62320": {
     "BridgedUSDC": "0xD4079B322c392D6b196f90AA4c439fC2C16d6770",
@@ -52,7 +53,7 @@
     "GrandaMento": "0xecf09fcd57b0c8b1fd3de92d59e234b88938485b",
     "MentoLabsMultisig": "0x56fD3F2bEE130e9867942D0F463a16fBE49B8d81",
     "WatchdogMultisig": "0x823655c966be3b6344Efd4D2A0FE8d0a1e3D691B",
-    "CeloCommunityTreasury": "0x707D2B6Bd0acf76821AD5A09A1C6F43d6d6f692c",
+    "MentoFoundationMultisig": "0x707D2B6Bd0acf76821AD5A09A1C6F43d6d6f692c",
     "MentoLiquiditySupport": "0x6bD481a12cb2790E7EE805b9E6e7E91917DeEe6a",
     "FractalSigner": "0x2fCAb633adFA6aF8266025D63228047033c3ceD0"
   }


### PR DESCRIPTION
### Description

This PR updates the MUGOV to mint the Celo Community allocation to Mento foundation multisig address.

<img width="486" alt="image" src="https://github.com/mento-protocol/mento-deployment/assets/17413894/14dc0186-3871-432c-99e2-96c4e0fb532d">


### Other changes

- Removed the outstanding TODO for merkle tree

- Updated the MentoLabsMultisig address for alfajores to another address because the previous address was equal to PartialReserveMultisig which was causing problems with allocations on alfajores(350m instead of 300m for MentoLabsMultisig).

### Tested

Ran another deployment with post deployment checks

### Related issues

- Fixes #187 
