### PR TITLE
feat: update bash scripts to work for both governances

### DIFF
--- a/bin/cgp-check.sh
+++ b/bin/cgp-check.sh
@@ -5,23 +5,27 @@
 # Usage: yarn cgp:check
 #               -n <baklava|alfajores|celo>  -- network to submit the proposal to
 #               -u <upgrade_name>            -- name of the upgrade (MU01)
-# Example: yarn cgp:check -n baklava -u MU03 
+#               -g <celo|mento>              -- governance to use
+# Example: yarn cgp:check -n baklava -u MU03 -g mento
 ##############################################################################
 
 source "$(dirname "$0")/setup.sh"
 
 NETWORK=""
 UPGRADE=""
-while getopts n:u:p:sfr flag
+GOVERNANCE=""
+while getopts n:u:g:sfr flag
 do
     case "${flag}" in
         n) NETWORK=${OPTARG};;
         u) UPGRADE=${OPTARG};;
+        g) GOVERNANCE=${OPTARG};;
     esac
 done
 
 parse_network "$NETWORK"
 parse_upgrade "$UPGRADE"
+parse_gov "$GOVERNANCE"
 
 echo "👀  Checking $UPGRADE"
-forge script $(forge_skip $UPGRADE) --rpc-url $RPC_URL --skip .dev.sol --sig "check(string)" script/utils/SimulateUpgrade.sol:SimulateUpgrade $UPGRADE
+forge script $(forge_skip $UPGRADE) --rpc-url $RPC_URL --skip .dev.sol --sig "check(string)" $UTILS_DIR/SimulateUpgrade.sol:SimulateUpgrade $UPGRADE

--- a/bin/cgp-execute.sh
+++ b/bin/cgp-execute.sh
@@ -5,25 +5,29 @@
 # Usage: yarn cgp:execute
 #               -p                           -- proposalId
 #               -n <baklava|alfajores|celo>  -- network to submit the proposal to
+#               -g <celo|mento>              -- governance to use
 #               -s                           -- simulate the proposal (optional)
-# Example: yarn cgp -n baklava -u MU01 -p 1
+# Example: yarn cgp -n baklava -p 1 -g mento
 ##############################################################################
 
 source "$(dirname "$0")/setup.sh"
 
 NETWORK=""
 PROPOSAL_ID=""
+GOVERNANCE=""
 SIMULATE=false
-while getopts n:p:sfr flag
+while getopts n:p:g:sfr flag
 do
     case "${flag}" in
         n) NETWORK=${OPTARG};;
         p) PROPOSAL_ID=${OPTARG};;
+        g) GOVERNANCE=${OPTARG};;
         s) SIMULATE=true;;
     esac
 done
 
 parse_network "$NETWORK"
+parse_gov "$GOVERNANCE"
 
 if [ -z "$PROPOSAL_ID" ]; then
     echo "🚨 No proposal ID provided"
@@ -32,9 +36,9 @@ fi
 
 if [ "$SIMULATE" = true ] ; then
     echo "🥸 Simulating execution of proposal $PROPOSAL_ID on $NETWORK"
-    forge script --rpc-url $RPC_URL --sig "run(uint256)" script/utils/ExecuteProposal.sol:ExecuteProposal $PROPOSAL_ID -vvvv
+    forge script --rpc-url $RPC_URL --sig "run(uint256)" $UTILS_DIR/ExecuteProposal.sol:ExecuteProposal $PROPOSAL_ID -vvvv
 else 
     echo "🔥 Executing proposal $PROPOSAL_ID on $NETWORK"
     confirm_if_celo "$NETWORK"
-    forge script --rpc-url $RPC_URL --sig "run(uint256)" script/utils/ExecuteProposal.sol:ExecuteProposal $PROPOSAL_ID --broadcast -vvvv --verify --verifier sourcify
+    forge script --rpc-url $RPC_URL --sig "run(uint256)" $UTILS_DIR/ExecuteProposal.sol:ExecuteProposal $PROPOSAL_ID --broadcast -vvvv --verify --verifier sourcify
 fi

--- a/bin/cgp.sh
+++ b/bin/cgp.sh
@@ -5,24 +5,27 @@
 # Usage: yarn cgp
 #               -n <baklava|alfajores|celo>  -- network to submit the proposal to
 #               -u <upgrade_name>            -- name of the upgrade (MU01)
+#               -g <celo|mento>              -- governance to use
 #               -s                           -- simulate the proposal (optional)
-#               -r                           -- revert
+#               -r                           -- revert (optional)
 #               -f                           -- use forked network (optional)
-# Example: yarn cgp -n baklava -u MU01 -p 1
+# Example: yarn cgp -n baklava -u MU01 -g mento
 ##############################################################################
 
 source "$(dirname "$0")/setup.sh"
 
 NETWORK=""
 UPGRADE=""
+GOVERNANCE=""
 SIMULATE=false
 USE_FORK=false
 REVERT=false
-while getopts n:u:p:sfr flag
+while getopts n:u:g:sfr flag
 do
     case "${flag}" in
         n) NETWORK=${OPTARG};;
         u) UPGRADE=${OPTARG};;
+        g) GOVERNANCE=${OPTARG};;
         s) SIMULATE=true;;
         f) USE_FORK=true;;
         r) REVERT=true;;
@@ -31,6 +34,7 @@ done
 
 parse_network "$NETWORK"
 parse_upgrade "$UPGRADE"
+parse_gov "$GOVERNANCE"
 
 if [ "$USE_FORK" = true ] ; then
     # Make sure you're running a local anvil node:
@@ -49,8 +53,8 @@ else
 fi
 
 if [ "$SIMULATE" = true ] ; then
-    echo "🥸 Simulating $CONTRACT"
-    forge script $(forge_skip $UPGRADE) --rpc-url $RPC_URL --skip .dev.sol --sig "run(string)" script/utils/SimulateUpgrade.sol:SimulateUpgrade $CONTRACT
+    echo "🥸  Simulating $CONTRACT"
+    forge script $(forge_skip $UPGRADE) --rpc-url $RPC_URL --skip .dev.sol --sig "run(string)" $UTILS_DIR/SimulateUpgrade.sol:SimulateUpgrade $CONTRACT
 else 
     echo "🔥 Submitting $CONTRACT"
     confirm_if_celo "$NETWORK"

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -49,6 +49,26 @@ parse_upgrade () { # $1: upgrade
     fi
 }
 
+parse_gov () { # $1: governance
+    if [ -z "$1" ]; then
+        echo "🚨 No governance provided (-g)"
+        exit 1
+    fi
+
+    case $1 in
+        "celo")
+            UTILS_DIR="script/utils"
+            ;;
+        "mento")
+            UTILS_DIR="script/utils/mento"
+            ;;
+        *)
+            echo "🚨 Invalid governance: '$1' (celo|mento)"
+            exit 1
+    esac
+    echo "🗳️  Governance in use: $1"
+}
+
 forge_skip () { # $1: target
     if [ "dev" = $1 ]; then
         # If target is dev script, skip all upgrades


### PR DESCRIPTION
### Description

Updates bash scripts to work with both Celo and Mento governances at the same time by introducing a new flag "-g".
If the governance is "celo", everything should work as before
If the governance is "mento", util scripts under "/mento" subfolder should be used to perform operations on the Mento Governance

### Other changes

Removed some unused flags and updated some related comments in bash scripts

### Tested

Tested by running MUGOV on Celo gov
Mento gov side can not be tested until the rest of the scripts are created

### Related issues

- Fixes [#476](https://github.com/mento-protocol/mento-general/issues/476)


### Backwards compatibility

Compatible


