### PR TITLE
PUSO (PSO) config

### DIFF
--- a/script/upgrades/PUSO/Config.sol
+++ b/script/upgrades/PUSO/Config.sol
@@ -31,7 +31,7 @@ library PSOConfig {
   function get(Contracts.Cache storage contracts) internal view returns (PSO memory config) {
     config.poolConfig = PSOcUSD_PoolConfig(contracts);
     config.rateFeedConfig = PHPUSD_RateFeedConfig();
-    config.stableTokenConfig = stableTokenKESConfig();
+    config.stableTokenConfig = stableTokenPSOConfig();
   }
 
   /* ==================== Rate Feed Configuration ==================== */

--- a/script/upgrades/PUSO/Config.sol
+++ b/script/upgrades/PUSO/Config.sol
@@ -98,7 +98,7 @@ library PSOConfig {
   /**
    * @dev Returns the configuration for the PUSO stable token.
    */
-  function stableTokenKESConfig() internal pure returns (Config.StableTokenV2 memory config) {
+  function stableTokenPSOConfig() internal pure returns (Config.StableTokenV2 memory config) {
     config = Config.StableTokenV2({ name: "PUSO", symbol: "PSO" });
   }
 }

--- a/script/upgrades/PUSO/Config.sol
+++ b/script/upgrades/PUSO/Config.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// solhint-disable func-name-mixedcase, contract-name-camelcase, function-max-lines, var-name-mixedcase
+pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
+
+import { Chain } from "script/utils/Chain.sol";
+import { Config } from "script/utils/Config.sol";
+import { Contracts } from "script/utils/Contracts.sol";
+import { FixidityLib } from "script/utils/FixidityLib.sol";
+
+/**
+ * @dev This library contains the configuration required for the PSO governance proposal.
+ *      The following configuration is used:
+ *     - 1 pool: PSO<->cUSD
+ *     - 1 rate feed: PHPUSD
+ *     - Configuration params needed to initialize the PSO stable token
+ */
+library PSOConfig {
+  using FixidityLib for FixidityLib.Fraction;
+  using Contracts for Contracts.Cache;
+
+  struct PSO {
+    Config.Pool poolConfig;
+    Config.RateFeed rateFeedConfig;
+    Config.StableTokenV2 stableTokenConfig;
+  }
+
+  /**
+   * @dev Returns the populated configuration object for the PSO governance proposal.
+   */
+  function get(Contracts.Cache storage contracts) internal view returns (PSO memory config) {
+    config.poolConfig = PSOcUSD_PoolConfig(contracts);
+    config.rateFeedConfig = PHPUSD_RateFeedConfig();
+    config.stableTokenConfig = stableTokenKESConfig();
+  }
+
+  /* ==================== Rate Feed Configuration ==================== */
+
+  /**
+   * @dev Returns the configuration for the PHPUSD rate feed.
+   */
+  function PHPUSD_RateFeedConfig() internal pure returns (Config.RateFeed memory rateFeedConfig) {
+    rateFeedConfig.rateFeedID = Config.rateFeedID("PHPUSD");
+    rateFeedConfig.medianDeltaBreaker0 = Config.MedianDeltaBreaker({
+      enabled: true,
+      threshold: FixidityLib.newFixedFraction(4, 100), // 4%
+      cooldown: 15 minutes,
+      smoothingFactor: FixidityLib.newFixedFraction(5, 1000).unwrap() // 0.005
+    });
+  }
+
+  /* ==================== Pool Configuration ==================== */
+
+  /**
+   * @dev Returns the configuration for the PSOcUSD pool.
+   */
+  function PSOcUSD_PoolConfig(
+    Contracts.Cache storage contracts
+  ) internal view returns (Config.Pool memory poolConfig) {
+    poolConfig = Config.Pool({
+      asset0: contracts.celoRegistry("StableToken"),
+      asset1: contracts.deployed("StableTokenPSOProxy"),
+      isConstantSum: true,
+      spread: FixidityLib.newFixedFraction(3, 1000), // 0.3%, in line with current DT of chainlink feed
+      referenceRateResetFrequency: 5 minutes,
+      minimumReports: 1,
+      stablePoolResetSize: 10_000_000 * 1e18,
+      referenceRateFeedID: Config.rateFeedID("PHPUSD"),
+      asset0limits: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 200_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 1_000_000,
+        enabledGlobal: true,
+        limitGlobal: 5_000_000
+      }),
+      asset1limits: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 57 * 200_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 57 * 1_000_000,
+        enabledGlobal: true,
+        limitGlobal: 57 * 5_000_000
+      })
+    });
+
+    if (Chain.isBaklava() || Chain.isAlfajores()) {
+      poolConfig.minimumReports = 1;
+    }
+  }
+
+  /* ==================== Stable Token Configuration ==================== */
+
+  /**
+   * @dev Returns the configuration for the PUSO stable token.
+   */
+  function stableTokenKESConfig() internal pure returns (Config.StableTokenV2 memory config) {
+    config = Config.StableTokenV2({ name: "PUSO", symbol: "PSO" });
+  }
+}


### PR DESCRIPTION
Context:

Naming is a bit unusual: Stablecoin is supposed to be named “PUSO'' which means “heart” in Filipino. Ticker is PSO and reference rate is the Philippine Peso (PHP). 

PHP/USD spread in fx markets are quite tight and chainlink deviation threshold (DT) for the PHP/USD feed is 0.3% - suggested 0.3% spread therefore with the intend to lower it when chainlink lowers the DT.

Trading limits 2x cKES - that means 5m in USD max. supply cap for now.

Same circuit breaker parameters as cKES.