### PR TITLE
feat: convert uint ts 2 str

### DIFF
--- a/script/utils/mento/GovernanceHelper.sol
+++ b/script/utils/mento/GovernanceHelper.sol
@@ -5,6 +5,7 @@ import { Script, console2 } from "forge-std/Script.sol";
 import { ICeloGovernance } from "../../interfaces/ICeloGovernance.sol";
 import { IGovernor } from "../../interfaces/IGovernor.sol";
 import { Chain } from "./Chain.sol";
+import { Contracts } from "./Contracts.sol";
 
 contract GovernanceHelper is Script {
   struct MentoGovernanceTransaction {
@@ -23,7 +24,7 @@ contract GovernanceHelper is Script {
       verifyDescription(descriptionURL);
     } else {
       // Add timestamp to the description URL on testnets to avoid proposalId conflicts
-      descriptionURL = string(abi.encodePacked(descriptionURL, abi.encode(block.timestamp)));
+      descriptionURL = string(abi.encodePacked(descriptionURL, "-", Contracts.uint2str(block.timestamp)));
     }
 
     MentoGovernanceTransaction memory govTx;


### PR DESCRIPTION
### Description

We were not properly encoding the TS to string before for testnet proposals, which was causing buggy proposal names for testnet proposals.

<img width="156" alt="image" src="https://github.com/user-attachments/assets/bdbab61d-f982-4579-9d96-0b8a4e31bb4e">


This pr fixes that issue by using the uint2str function.

### Other changes

no

### Tested

<img width="183" alt="image" src="https://github.com/user-attachments/assets/665b0878-a22d-4958-ab85-b65a3c6a075c">

### Related issues

- Not tracked

