### PR TITLE
fix: update cCOP pool reset frequency

### DIFF
--- a/script/upgrades/cCOP/Config.sol
+++ b/script/upgrades/cCOP/Config.sol
@@ -67,7 +67,7 @@ library cCOPConfig {
       asset1: contracts.deployed("StableTokenCOPProxy"),
       isConstantSum: true,
       spread: FixidityLib.newFixedFraction(3, 1000), // 0.3%, in line with current DT of chainlink feed
-      referenceRateResetFrequency: 5 minutes,
+      referenceRateResetFrequency: 6 minutes,
       minimumReports: 1,
       stablePoolResetSize: 10_000_000 * 1e18,
       referenceRateFeedID: Config.rateFeedID("relayed:COPUSD"),

--- a/script/upgrades/cCOP/Config.sol
+++ b/script/upgrades/cCOP/Config.sol
@@ -40,8 +40,6 @@ library cCOPConfig {
    * @dev Returns the configuration for the COPUSD rate feed.
    */
   function COPUSD_RateFeedConfig() internal pure returns (Config.RateFeed memory rateFeedConfig) {
-    // TODO: Get confirmation for Roman that these are OK
-    // These are the exact same as the $PUSO rate feed config
     rateFeedConfig.rateFeedID = Config.rateFeedID("relayed:COPUSD");
     rateFeedConfig.medianDeltaBreaker0 = Config.MedianDeltaBreaker({
       enabled: true,
@@ -59,9 +57,6 @@ library cCOPConfig {
   function cCOPcUSD_PoolConfig(
     Contracts.Cache storage contracts
   ) internal view returns (Config.Pool memory poolConfig) {
-    // TODO: Get confirmation from Roman that these are OK
-    // These were taken from the $PUSO pool and adjusted to the COP/USD exchange rate,
-    // which was 0.00023747 at the time of writing
     poolConfig = Config.Pool({
       asset0: contracts.celoRegistry("StableToken"),
       asset1: contracts.deployed("StableTokenCOPProxy"),


### PR DESCRIPTION
### Description

Chainlink often reports prices very close to the 5 minutes mark, we sometimes end up in a situation where the pool no longer has a valid median until the new price is relayed, essentially disabling trading against the pool. Because of this we are increasing the `referenceRateResetFrequency` parameter of the pool to `6 minutes` so that there's a bit more buffer when relaying the chainlink price. This parameter is used in the [oracleHasValidMedian function](https://github.com/mento-protocol/mento-core/blob/develop/contracts/swap/BiPoolManager.sol#L527) inside the biPoolManager. This goes together with what we already did during the oracle whitelist proposal where we also increased the [report expiry time](https://github.com/mento-protocol/mento-deployment/pull/228/files#diff-e297bcdf0b5c9eaa0945ef85a8f761a3be3dc9eb1ca22c362c59cd6be2bbed1dR99-R104). 

### Other changes

N/A

### Tested

Simulation is still green. `referenceRateResetFrequency` is only used inside `shouldUpdateBuckets` and `oracleHasValidMedian` [in the biPoolManager](https://github.com/mento-protocol/mento-core/blob/develop/contracts/swap/BiPoolManager.sol), so this change shouldn't have any other impact.
