### PR TITLE
feat: add partial reserve multisig as other reserve addresses

### DIFF
--- a/script/upgrades/MU08/MU08.md
+++ b/script/upgrades/MU08/MU08.md
@@ -3,7 +3,7 @@
 Transfer ownership of the MentoProtocol contracts to Mento Governance.
 
 Proposal Summary:
-This proposal transfers ownership of the MentoProtocol contracts to Mento Governance. This will allow Mento token holders to own and manage the protocol.
+This proposal transfers ownership of the MentoProtocol contracts to Mento Governance. This will allow Mento token holders to own and manage the protocol. Additionally it adds Reserve Multisig as an "Other Reserve Address" of onchain Reserve contract and removes old other reserve addresses.
 
 Contracts to Transfer Ownership:
 


### PR DESCRIPTION
### Description

Removes Anchorage addresses and instead whitelist the Reserve Multisig(0x87647780180B8f55980C7D3fFeFe08a9B29e9aE1) as `otherReserveAddresses` for onchain Reserve contract

### Other changes

no

### Tested

Simulated on alfajores

### Related issues

- Fixes #229 
