### PR TITLE
feat: add script to deploy locking proxy admin

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -10,3 +10,4 @@ mento-core-2.2.0/=lib/mento-core-2.2.0/contracts/
 mento-core-2.3.1/=lib/mento-core-2.3.1/contracts/
 mento-core-2.5.0/=lib/mento-core-2.5.0/contracts/
 merkle-distributor/=lib/merkle-distributor/contracts/
+mento-core-2.6.0-oz/=lib/mento-core-2.6.0/lib/openzeppelin-contracts-next

--- a/remappings.txt
+++ b/remappings.txt
@@ -11,3 +11,4 @@ mento-core-2.3.1/=lib/mento-core-2.3.1/contracts/
 mento-core-2.5.0/=lib/mento-core-2.5.0/contracts/
 merkle-distributor/=lib/merkle-distributor/contracts/
 mento-core-2.6.0-oz/=lib/mento-core-2.6.0/lib/openzeppelin-contracts-next
+mento-core-2.6.0-tp/=lib/mento-core-2.6.0/lib/openzeppelin-contracts-next/contracts/proxy/transparent

--- a/remappings.txt
+++ b/remappings.txt
@@ -11,4 +11,3 @@ mento-core-2.3.1/=lib/mento-core-2.3.1/contracts/
 mento-core-2.5.0/=lib/mento-core-2.5.0/contracts/
 merkle-distributor/=lib/merkle-distributor/contracts/
 mento-core-2.6.0-oz/=lib/mento-core-2.6.0/lib/openzeppelin-contracts-next
-mento-core-2.6.0-tp/=lib/mento-core-2.6.0/lib/openzeppelin-contracts-next/contracts/proxy/transparent

--- a/remappings.txt
+++ b/remappings.txt
@@ -11,3 +11,4 @@ mento-core-2.3.1/=lib/mento-core-2.3.1/contracts/
 mento-core-2.5.0/=lib/mento-core-2.5.0/contracts/
 merkle-distributor/=lib/merkle-distributor/contracts/
 mento-core-2.6.0-oz/=lib/mento-core-2.6.0/lib/openzeppelin-contracts-next
+mento-core-2.6.0/=lib/mento-core-2.6.0/contracts/

--- a/script/interfaces/IGovernanceFactory.sol
+++ b/script/interfaces/IGovernanceFactory.sol
@@ -29,4 +29,6 @@ interface IGovernanceFactory {
   function mentoGovernor() external view returns (address);
 
   function locking() external view returns (address);
+
+  function proxyAdmin() external view returns (address);
 }

--- a/script/upgrades/MU09/MU09.md
+++ b/script/upgrades/MU09/MU09.md
@@ -1,0 +1,25 @@
+### MU09: Transfer Locking Contract Ownership
+
+#### Description
+Currently, Mento Governance and Locking contracts have a circular dependency - any issues in the Locking contracts could prevent governance from executing upgrades since governance requires Locking to function properly. With the upcoming Celo L2 transition bringing breaking changes to Locking contracts, we need to temporarily transfer upgradability rights to another account to ensure we can upgrade Locking contracts without depending on them being in a perfect state.
+
+#### Changes
+1. Deploy a new ProxyAdmin contract owned by the MentoLabs multisig
+2. Transfer proxy ownership of all Locking contracts to this new ProxyAdmin
+
+#### Motivation
+This change breaks the circular dependency between governance and Locking contracts, allowing us to:
+- Safely upgrade Locking contracts if issues arise
+- Prepare for Celo L2 transition breaking changes
+- Maintain ability to fix critical issues without being blocked by Locking contract state
+
+#### Security Considerations
+- The MentoLabs multisig will temporarily have direct upgrade rights over Locking contracts
+- This is a temporary security tradeoff to prevent potential system deadlock
+- Plan to return ownership to governance after L2 transition is complete
+
+#### Testing
+- Deploy ProxyAdmin with correct ownership
+- Verify successful transfer of Locking proxy ownership
+- Confirm MentoLabs multisig can execute upgrades
+- Validate governance can still function normally

--- a/script/upgrades/MU09/MU09.md
+++ b/script/upgrades/MU09/MU09.md
@@ -19,7 +19,5 @@ This change breaks the circular dependency between governance and Locking contra
 - Plan to return ownership to governance after L2 transition is complete
 
 #### Testing
-- Deploy ProxyAdmin with correct ownership
+- Deploy ProxyAdmin with correct ownership(Mento labs multisig)
 - Verify successful transfer of Locking proxy ownership
-- Confirm MentoLabs multisig can execute upgrades
-- Validate governance can still function normally

--- a/script/upgrades/MU09/MU09.md
+++ b/script/upgrades/MU09/MU09.md
@@ -1,23 +1,29 @@
 ### MU09: Transfer Locking Contract Ownership
 
 #### Description
+
 Currently, Mento Governance and Locking contracts have a circular dependency - any issues in the Locking contracts could prevent governance from executing upgrades since governance requires Locking to function properly. With the upcoming Celo L2 transition bringing breaking changes to Locking contracts, we need to temporarily transfer upgradability rights to another account to ensure we can upgrade Locking contracts without depending on them being in a perfect state.
 
 #### Changes
+
 1. Deploy a new ProxyAdmin contract owned by the MentoLabs multisig
 2. Transfer proxy ownership of all Locking contracts to this new ProxyAdmin
 
 #### Motivation
+
 This change breaks the circular dependency between governance and Locking contracts, allowing us to:
+
 - Safely upgrade Locking contracts if issues arise
 - Prepare for Celo L2 transition breaking changes
 - Maintain ability to fix critical issues without being blocked by Locking contract state
 
 #### Security Considerations
+
 - The MentoLabs multisig will temporarily have direct upgrade rights over Locking contracts
 - This is a temporary security tradeoff to prevent potential system deadlock
 - Plan to return ownership to governance after L2 transition is complete
 
 #### Testing
+
 - Deploy ProxyAdmin with correct ownership(Mento labs multisig)
 - Verify successful transfer of Locking proxy ownership

--- a/script/upgrades/MU09/MU09.sol
+++ b/script/upgrades/MU09/MU09.sol
@@ -1,22 +1,24 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // solhint-disable func-name-mixedcase, contract-name-camelcase, function-max-lines, var-name-mixedcase
-pragma solidity ^0.5.13;
+pragma solidity ^0.8;
 pragma experimental ABIEncoderV2;
 
 import { GovernanceScript } from "script/utils/mento/Script.sol";
 import { console } from "forge-std/console.sol";
-import { Contracts } from "script/utils/Contracts.sol";
-import { Chain } from "script/utils/Chain.sol";  
+import { Contracts } from "script/utils/mento/Contracts.sol";
+import { Chain } from "script/utils/mento/Chain.sol";
 
 import { IGovernanceFactory } from "script/interfaces/IGovernanceFactory.sol";
 import { IMentoUpgrade, ICeloGovernance } from "script/interfaces/IMentoUpgrade.sol";
 
-interface IOwnableLite { 
+interface IOwnableLite {
   function transferOwnership(address recipient) external;
 }
 
 contract MU09 is IMentoUpgrade, GovernanceScript {
   using Contracts for Contracts.Cache;
+
+  bool public hasChecks = true;
 
   address public mentoGovernor;
   address public lockingProxyAdmin;
@@ -76,7 +78,7 @@ contract MU09 is IMentoUpgrade, GovernanceScript {
     _transactions[0] = ICeloGovernance.Transaction(
       0,
       lockingProxy,
-      abi.encodeWithSelector(IOwnableLite(0).transferOwnership.selector, lockingProxyAdmin)
+      abi.encodeWithSelector(IOwnableLite.transferOwnership.selector, lockingProxyAdmin)
     );
 
     return _transactions;

--- a/script/upgrades/MU09/MU09.sol
+++ b/script/upgrades/MU09/MU09.sol
@@ -46,11 +46,9 @@ contract MU09 is IMentoUpgrade, GovernanceScript {
 
     // Get newly deployed LockingProxyAdmin address
     lockingProxyAdmin = contracts.deployed("ProxyAdmin");
-    require(lockingProxyAdmin != address(0), "LockingProxyAdmin address not found");
 
     // Get and set the governance factory
     address governanceFactoryAddress = contracts.deployed("GovernanceFactory");
-    require(governanceFactoryAddress != address(0), "GovernanceFactory address not found");
     governanceFactory = IGovernanceFactory(governanceFactoryAddress);
 
     // Get the mento governor address

--- a/script/upgrades/MU09/MU09.sol
+++ b/script/upgrades/MU09/MU09.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// solhint-disable func-name-mixedcase, contract-name-camelcase, function-max-lines, var-name-mixedcase
+pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
+
+import { GovernanceScript } from "script/utils/mento/Script.sol";
+import { console } from "forge-std/console.sol";
+import { Contracts } from "script/utils/Contracts.sol";
+import { Chain } from "script/utils/Chain.sol";  
+
+import { IGovernanceFactory } from "script/interfaces/IGovernanceFactory.sol";
+import { IMentoUpgrade, ICeloGovernance } from "script/interfaces/IMentoUpgrade.sol";
+
+interface IOwnableLite { 
+  function transferOwnership(address recipient) external;
+}
+
+contract MU09 is IMentoUpgrade, GovernanceScript {
+  using Contracts for Contracts.Cache;
+
+  address public mentoGovernor;
+  address public lockingProxyAdmin;
+  address public lockingProxy;
+
+  IGovernanceFactory public governanceFactory;
+
+  /**
+   * @dev Loads the contracts from previous deployments
+   */
+  function loadDeployedContracts() public {
+    // Load load deployment with governance factory
+    contracts.loadSilent("MUGOV-00-Create-Factory", "latest");
+
+    // Load the deployed ProxyAdmin contract
+    contracts.loadSilent("MU09-Deploy-LockingProxyAdmin", "latest");
+  }
+
+  function prepare() public {
+    loadDeployedContracts();
+
+    // Get newly deployed LockingProxyAdmin address
+    lockingProxyAdmin = contracts.deployed("ProxyAdmin");
+    require(lockingProxyAdmin != address(0), "LockingProxyAdmin address not found");
+
+    // Get and set the governance factory
+    address governanceFactoryAddress = contracts.deployed("GovernanceFactory");
+    require(governanceFactoryAddress != address(0), "GovernanceFactory address not found");
+    governanceFactory = IGovernanceFactory(governanceFactoryAddress);
+
+    // Get the mento governor address
+    mentoGovernor = governanceFactory.mentoGovernor();
+    require(mentoGovernor != address(0), "MentoGovernor address not found");
+
+    // Get the locking proxy address
+    lockingProxy = governanceFactory.locking();
+    require(lockingProxy != address(0), "LockingProxy address not found");
+  }
+
+  function run() public {
+    prepare();
+
+    ICeloGovernance.Transaction[] memory _transactions = buildProposal();
+
+    vm.startBroadcast(Chain.deployerPrivateKey());
+    {
+      // TODO: Change this to the forum post URL
+      createProposal(_transactions, "https://CHANGE-ME-PLEASE", mentoGovernor);
+    }
+    vm.stopBroadcast();
+  }
+
+  function buildProposal() public returns (ICeloGovernance.Transaction[] memory) {
+    ICeloGovernance.Transaction[] memory _transactions = new ICeloGovernance.Transaction[](1);
+
+    // Create transaction to transfer proxy ownership
+    _transactions[0] = ICeloGovernance.Transaction(
+      0,
+      lockingProxy,
+      abi.encodeWithSelector(IOwnableLite(0).transferOwnership.selector, lockingProxyAdmin)
+    );
+
+    return _transactions;
+  }
+}

--- a/script/upgrades/MU09/MU09Checks.sol
+++ b/script/upgrades/MU09/MU09Checks.sol
@@ -8,7 +8,7 @@ import { Contracts } from "script/utils/mento/Contracts.sol";
 import { Test } from "forge-std/Test.sol";
 
 import { IGovernanceFactory } from "script/interfaces/IGovernanceFactory.sol";
-import { ITransparentUpgradeableProxy } from "mento-core-2.6.0-oz/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { ITransparentUpgradeableProxy } from "mento-core-2.6.0-tp/TransparentUpgradeableProxy.sol";
 
 interface IProxyAdminLite {
   function getProxyAdmin(address proxy) external view returns (address);

--- a/script/upgrades/MU09/MU09Checks.sol
+++ b/script/upgrades/MU09/MU09Checks.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
+
+import { GovernanceScript } from "script/utils/mento/Script.sol";
+import { console } from "forge-std/console.sol";
+import { Contracts } from "script/utils/Contracts.sol";
+import { Test } from "forge-std/Test.sol";
+
+import { IGovernanceFactory } from "script/interfaces/IGovernanceFactory.sol";
+
+interface IOwnableLite {
+  function owner() external view returns (address);
+
+  function transferOwnership(address recipient) external;
+}
+
+contract MU09Checks is GovernanceScript, Test {
+  using Contracts for Contracts.Cache;
+
+  address public lockingProxyAdmin;
+  address public lockingProxy;
+  address public mentoLabsMultisig;
+
+  function prepare() public {
+    // Load addresses from deployments
+    contracts.loadSilent("MUGOV-00-Create-Factory", "latest");
+    contracts.loadSilent("MU09-Deploy-LockingProxyAdmin", "latest");
+
+    mentoLabsMultisig = contracts.dependency("MentoLabsMultisig");
+    require(mentoLabsMultisig != address(0), "MentoLabsMultisig address not found");
+
+    // Get newly deployed LockingProxyAdmin address
+    lockingProxyAdmin = contracts.deployed("ProxyAdmin");
+    require(lockingProxyAdmin != address(0), "LockingProxyAdmin address not found");
+
+    // Get and set the governance factory
+    address governanceFactoryAddress = contracts.deployed("GovernanceFactory");
+    require(governanceFactoryAddress != address(0), "GovernanceFactory address not found");
+    IGovernanceFactory governanceFactory = IGovernanceFactory(governanceFactoryAddress);
+
+    // Get the locking proxy address
+    lockingProxy = governanceFactory.locking();
+    require(lockingProxy != address(0), "LockingProxy address not found");
+  }
+
+  function run() public {
+    console.log("\nStarting MU09 checks:");
+    prepare();
+
+    verifyLockingProxyAdminOwnership();
+    verifyLockingProxyOwnership();
+  }
+
+  function verifyLockingProxyAdminOwnership() public {
+    console.log("\n== Verifying locking proxy admin ownership: ==");
+
+    address lockingProxyAdminOwner = IOwnableLite(lockingProxyAdmin).owner();
+    require(lockingProxyAdminOwner == mentoLabsMultisig, "LockingProxyAdmin owner is not MentoLabsMultisig");
+    console.log("🟢 LockingProxyAdmin owner is MentoLabsMultisig: %s", lockingProxyAdminOwner);
+  }
+
+  function verifyLockingProxyOwnership() public {
+    console.log("\n== Verifying locking proxy ownership: ==");
+
+    address lockingProxyOwner = IOwnableLite(lockingProxy).owner();
+    require(lockingProxyOwner == lockingProxyAdmin, "LockingProxy owner is not LockingProxyAdmin");
+    console.log("🟢 LockingProxy owner is LockingProxyAdmin: %s", lockingProxyOwner);
+  }
+}

--- a/script/upgrades/MU09/MU09Checks.sol
+++ b/script/upgrades/MU09/MU09Checks.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity ^0.5.13;
+pragma solidity ^0.8;
 pragma experimental ABIEncoderV2;
 
 import { GovernanceScript } from "script/utils/mento/Script.sol";
 import { console } from "forge-std/console.sol";
-import { Contracts } from "script/utils/Contracts.sol";
+import { Contracts } from "script/utils/mento/Contracts.sol";
 import { Test } from "forge-std/Test.sol";
 
 import { IGovernanceFactory } from "script/interfaces/IGovernanceFactory.sol";
@@ -57,7 +57,7 @@ contract MU09Checks is GovernanceScript, Test {
 
     address lockingProxyAdminOwner = IOwnableLite(lockingProxyAdmin).owner();
     require(lockingProxyAdminOwner == mentoLabsMultisig, "LockingProxyAdmin owner is not MentoLabsMultisig");
-    console.log("🟢 LockingProxyAdmin owner is MentoLabsMultisig: %s", lockingProxyAdminOwner);
+    console.log(unicode"🟢 LockingProxyAdmin owner is MentoLabsMultisig: %s", lockingProxyAdminOwner);
   }
 
   function verifyLockingProxyOwnership() public {
@@ -65,6 +65,6 @@ contract MU09Checks is GovernanceScript, Test {
 
     address lockingProxyOwner = IOwnableLite(lockingProxy).owner();
     require(lockingProxyOwner == lockingProxyAdmin, "LockingProxy owner is not LockingProxyAdmin");
-    console.log("🟢 LockingProxy owner is LockingProxyAdmin: %s", lockingProxyOwner);
+    console.log(unicode"🟢 LockingProxy owner is LockingProxyAdmin: %s", lockingProxyOwner);
   }
 }

--- a/script/upgrades/MU09/MU09Checks.sol
+++ b/script/upgrades/MU09/MU09Checks.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8;
 pragma experimental ABIEncoderV2;
+/* solhint-disable max-line-length */
 
 import { GovernanceScript } from "script/utils/mento/Script.sol";
 import { console } from "forge-std/console.sol";
@@ -8,9 +9,8 @@ import { Contracts } from "script/utils/mento/Contracts.sol";
 import { Test } from "forge-std/Test.sol";
 
 import { IGovernanceFactory } from "script/interfaces/IGovernanceFactory.sol";
-/* solhint-disable-next-line max-line-length */
-import { ITransparentUpgradeableProxy } from "mento-core-2.6.0-oz/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import { ProxyAdmin } from "mento-core-2.6.0-oz/contracts/proxy/transparent/ProxyAdmin.sol";
+import { ITransparentUpgradeableProxy } from "mento-core-2.6.0/../lib/openzeppelin-contracts-next/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { ProxyAdmin } from "mento-core-2.6.0/../lib/openzeppelin-contracts-next/contracts/proxy/transparent/ProxyAdmin.sol";
 
 contract MockImplementation {}
 

--- a/script/upgrades/MU09/MU09Checks.sol
+++ b/script/upgrades/MU09/MU09Checks.sol
@@ -9,16 +9,7 @@ import { Test } from "forge-std/Test.sol";
 
 import { IGovernanceFactory } from "script/interfaces/IGovernanceFactory.sol";
 import { ITransparentUpgradeableProxy } from "mento-core-2.6.0-tp/TransparentUpgradeableProxy.sol";
-
-interface IProxyAdminLite {
-  function getProxyAdmin(address proxy) external view returns (address);
-
-  function upgrade(ITransparentUpgradeableProxy proxy, address implementation) external;
-}
-
-interface IOwnableLite {
-  function owner() external view returns (address);
-}
+import { ProxyAdmin } from "mento-core-2.6.0-tp/ProxyAdmin.sol";
 
 contract MU09Checks is GovernanceScript, Test {
   using Contracts for Contracts.Cache;
@@ -63,7 +54,7 @@ contract MU09Checks is GovernanceScript, Test {
   function verifyLockingProxyAdminOwnership() public {
     console.log("\n== Verifying locking proxy admin ownership: ==");
 
-    address lockingProxyAdminOwner = IOwnableLite(newLockingProxyAdmin).owner();
+    address lockingProxyAdminOwner = ProxyAdmin(newLockingProxyAdmin).owner();
     require(lockingProxyAdminOwner == mentoLabsMultisig, "LockingProxyAdmin owner is not MentoLabsMultisig");
     console.log(unicode"🟢 LockingProxyAdmin owner is MentoLabsMultisig: %s", lockingProxyAdminOwner);
   }
@@ -71,7 +62,9 @@ contract MU09Checks is GovernanceScript, Test {
   function verifyLockingProxyAdminIsNewLockingProxyAdmin() public {
     console.log("\n== Verifying locking proxy admin is new locking proxy admin: ==");
 
-    address lockingProxyAdmin = IProxyAdminLite(newLockingProxyAdmin).getProxyAdmin(lockingProxy);
+    address lockingProxyAdmin = ProxyAdmin(newLockingProxyAdmin).getProxyAdmin(
+      ITransparentUpgradeableProxy(lockingProxy)
+    );
     require(lockingProxyAdmin == newLockingProxyAdmin, "LockingProxyAdmin is not the new LockingProxyAdmin");
     console.log(unicode"🟢 LockingProxyAdmin is new LockingProxyAdmin: %s", lockingProxyAdmin);
   }
@@ -86,6 +79,8 @@ contract MU09Checks is GovernanceScript, Test {
     vm.expectEmit(true, true, true, true);
     emit Upgraded(fakeImplementation);
 
-    IProxyAdminLite(newLockingProxyAdmin).upgrade(ITransparentUpgradeableProxy(lockingProxy), fakeImplementation);
+    ProxyAdmin(newLockingProxyAdmin).upgrade(ITransparentUpgradeableProxy(lockingProxy), fakeImplementation);
+
+    console.log(unicode"🟢 Multisig can upgrade implementation");
   }
 }

--- a/script/upgrades/MU09/MU09Checks.sol
+++ b/script/upgrades/MU09/MU09Checks.sol
@@ -11,6 +11,8 @@ import { IGovernanceFactory } from "script/interfaces/IGovernanceFactory.sol";
 import { ITransparentUpgradeableProxy } from "mento-core-2.6.0-tp/TransparentUpgradeableProxy.sol";
 import { ProxyAdmin } from "mento-core-2.6.0-tp/ProxyAdmin.sol";
 
+contract MockImplementation {}
+
 contract MU09Checks is GovernanceScript, Test {
   using Contracts for Contracts.Cache;
 
@@ -72,14 +74,15 @@ contract MU09Checks is GovernanceScript, Test {
   function verifyMultisigCanUpgrade() public {
     console.log("\n== Verifying the multisig can successfuly upgrade implementation: ==");
 
-    address fakeImplementation = mentoLabsMultisig;
+    // Deploy a mock implementation
+    MockImplementation mockImplementation = new MockImplementation();
     vm.startPrank(mentoLabsMultisig);
 
     // Verify that the upgrade event is emitted with the fake implementation
     vm.expectEmit(true, true, true, true);
-    emit Upgraded(fakeImplementation);
+    emit Upgraded(address(mockImplementation));
 
-    ProxyAdmin(newLockingProxyAdmin).upgrade(ITransparentUpgradeableProxy(lockingProxy), fakeImplementation);
+    ProxyAdmin(newLockingProxyAdmin).upgrade(ITransparentUpgradeableProxy(lockingProxy), address(mockImplementation));
 
     console.log(unicode"🟢 Multisig can upgrade implementation");
   }

--- a/script/upgrades/MU09/MU09Checks.sol
+++ b/script/upgrades/MU09/MU09Checks.sol
@@ -8,8 +8,9 @@ import { Contracts } from "script/utils/mento/Contracts.sol";
 import { Test } from "forge-std/Test.sol";
 
 import { IGovernanceFactory } from "script/interfaces/IGovernanceFactory.sol";
-import { ITransparentUpgradeableProxy } from "mento-core-2.6.0-tp/TransparentUpgradeableProxy.sol";
-import { ProxyAdmin } from "mento-core-2.6.0-tp/ProxyAdmin.sol";
+/* solhint-disable-next-line max-line-length */
+import { ITransparentUpgradeableProxy } from "mento-core-2.6.0-oz/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { ProxyAdmin } from "mento-core-2.6.0-oz/contracts/proxy/transparent/ProxyAdmin.sol";
 
 contract MockImplementation {}
 

--- a/script/upgrades/MU09/MU09Checks.sol
+++ b/script/upgrades/MU09/MU09Checks.sol
@@ -9,16 +9,18 @@ import { Test } from "forge-std/Test.sol";
 
 import { IGovernanceFactory } from "script/interfaces/IGovernanceFactory.sol";
 
+interface IProxyAdminLite {
+  function getProxyAdmin(address proxy) external view returns (address);
+}
+
 interface IOwnableLite {
   function owner() external view returns (address);
-
-  function transferOwnership(address recipient) external;
 }
 
 contract MU09Checks is GovernanceScript, Test {
   using Contracts for Contracts.Cache;
 
-  address public lockingProxyAdmin;
+  address public newLockingProxyAdmin;
   address public lockingProxy;
   address public mentoLabsMultisig;
 
@@ -31,8 +33,8 @@ contract MU09Checks is GovernanceScript, Test {
     require(mentoLabsMultisig != address(0), "MentoLabsMultisig address not found");
 
     // Get newly deployed LockingProxyAdmin address
-    lockingProxyAdmin = contracts.deployed("ProxyAdmin");
-    require(lockingProxyAdmin != address(0), "LockingProxyAdmin address not found");
+    newLockingProxyAdmin = contracts.deployed("ProxyAdmin");
+    require(newLockingProxyAdmin != address(0), "LockingProxyAdmin address not found");
 
     // Get and set the governance factory
     address governanceFactoryAddress = contracts.deployed("GovernanceFactory");
@@ -49,22 +51,22 @@ contract MU09Checks is GovernanceScript, Test {
     prepare();
 
     verifyLockingProxyAdminOwnership();
-    verifyLockingProxyOwnership();
+    verifyLockingProxyAdminIsNewLockingProxyAdmin();
   }
 
   function verifyLockingProxyAdminOwnership() public {
     console.log("\n== Verifying locking proxy admin ownership: ==");
 
-    address lockingProxyAdminOwner = IOwnableLite(lockingProxyAdmin).owner();
+    address lockingProxyAdminOwner = IOwnableLite(newLockingProxyAdmin).owner();
     require(lockingProxyAdminOwner == mentoLabsMultisig, "LockingProxyAdmin owner is not MentoLabsMultisig");
     console.log(unicode"🟢 LockingProxyAdmin owner is MentoLabsMultisig: %s", lockingProxyAdminOwner);
   }
 
-  function verifyLockingProxyOwnership() public {
-    console.log("\n== Verifying locking proxy ownership: ==");
+  function verifyLockingProxyAdminIsNewLockingProxyAdmin() public {
+    console.log("\n== Verifying locking proxy admin is new locking proxy admin: ==");
 
-    address lockingProxyOwner = IOwnableLite(lockingProxy).owner();
-    require(lockingProxyOwner == lockingProxyAdmin, "LockingProxy owner is not LockingProxyAdmin");
-    console.log(unicode"🟢 LockingProxy owner is LockingProxyAdmin: %s", lockingProxyOwner);
+    address lockingProxyAdmin = IProxyAdminLite(newLockingProxyAdmin).getProxyAdmin(lockingProxy);
+    require(lockingProxyAdmin == newLockingProxyAdmin, "LockingProxyAdmin is not the new LockingProxyAdmin");
+    console.log(unicode"🟢 LockingProxyAdmin is new LockingProxyAdmin: %s", lockingProxyAdmin);
   }
 }

--- a/script/upgrades/MU09/deploy/MU09-Deploy-LockingProxyAdmin.sol
+++ b/script/upgrades/MU09/deploy/MU09-Deploy-LockingProxyAdmin.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// solhint-disable contract-name-camelcase
+pragma solidity ^0.8.18;
+
+import { console } from "forge-std-next/console.sol";
+import { Script } from "script/utils/mento/Script.sol";
+import { Chain as ChainLib } from "script/utils/mento/Chain.sol";
+import { Contracts } from "script/utils/mento/Contracts.sol";
+import { ProxyDeployerLib } from "mento-core-2.5.0/governance/deployers/ProxyDeployerLib.sol";
+
+interface IOwnableLite {
+    function transferOwnership(address newOwner) external;
+}
+
+contract MU09_Deploy_LockingProxyAdmin is Script {
+  using Contracts for Contracts.Cache;
+
+  function run() public { 
+    address mentoLabsMultisig = contracts.dependency("MentoLabsMultisig");
+    require(mentoLabsMultisig != address(0), "MentoLabsMultisig address not found");
+
+    vm.startBroadcast(ChainLib.deployerPrivateKey());
+    {
+      IOwnableLite proxyAdmin = ProxyDeployerLib.deployAdmin();
+      console.log("Deployed ProxyAdmin for Locking at: %s", address(proxyAdmin));
+
+      proxyAdmin.transferOwnership(mentoLabsMultisig);
+      console.log("Transferred LockingProxyAdmin ownership to MentoLabsMultisig: %s", mentoLabsMultisig);
+    }
+    vm.stopBroadcast();
+  }
+}

--- a/script/upgrades/MU09/deploy/MU09-Deploy-LockingProxyAdmin.sol
+++ b/script/upgrades/MU09/deploy/MU09-Deploy-LockingProxyAdmin.sol
@@ -6,12 +6,13 @@ import { console } from "forge-std-next/console.sol";
 import { Script } from "script/utils/mento/Script.sol";
 import { Chain as ChainLib } from "script/utils/mento/Chain.sol";
 import { Contracts } from "script/utils/mento/Contracts.sol";
-import { ProxyDeployerLib } from "mento-core-2.6.0/governance/deployers/ProxyDeployerLib.sol";
+import { ProxyAdmin } from "lib/mento-core-2.6.0/lib/openzeppelin-contracts-next/contracts/proxy/transparent/ProxyAdmin.sol";
 
 interface IOwnableLite {
   function transferOwnership(address newOwner) external;
 }
 
+// yarn cgp:deploy -n celo -u MU09 -f -g mento
 contract MU09_Deploy_LockingProxyAdmin is Script {
   using Contracts for Contracts.Cache;
 
@@ -21,8 +22,7 @@ contract MU09_Deploy_LockingProxyAdmin is Script {
 
     vm.startBroadcast(ChainLib.deployerPrivateKey());
     {
-      // Check out the name of the contract in the contracts cache. Could clash with other contracts
-      IOwnableLite proxyAdmin = IOwnableLite(address(ProxyDeployerLib.deployAdmin()));
+      IOwnableLite proxyAdmin = IOwnableLite(address(new ProxyAdmin()));
       console.log("Deployed ProxyAdmin for Locking at: %s", address(proxyAdmin));
 
       proxyAdmin.transferOwnership(mentoLabsMultisig);

--- a/script/upgrades/MU09/deploy/MU09-Deploy-LockingProxyAdmin.sol
+++ b/script/upgrades/MU09/deploy/MU09-Deploy-LockingProxyAdmin.sol
@@ -21,7 +21,8 @@ contract MU09_Deploy_LockingProxyAdmin is Script {
 
     vm.startBroadcast(ChainLib.deployerPrivateKey());
     {
-      IOwnableLite proxyAdmin = ProxyDeployerLib.deployAdmin();
+      // Check out the name of the contract in the contracts cache. Could clash with other contracts
+      IOwnableLite proxyAdmin = IOwnableLite(address(ProxyDeployerLib.deployAdmin()));
       console.log("Deployed ProxyAdmin for Locking at: %s", address(proxyAdmin));
 
       proxyAdmin.transferOwnership(mentoLabsMultisig);

--- a/script/upgrades/MU09/deploy/MU09-Deploy-LockingProxyAdmin.sol
+++ b/script/upgrades/MU09/deploy/MU09-Deploy-LockingProxyAdmin.sol
@@ -6,7 +6,7 @@ import { console } from "forge-std-next/console.sol";
 import { Script } from "script/utils/mento/Script.sol";
 import { Chain as ChainLib } from "script/utils/mento/Chain.sol";
 import { Contracts } from "script/utils/mento/Contracts.sol";
-import { ProxyAdmin } from "lib/mento-core-2.6.0/lib/openzeppelin-contracts-next/contracts/proxy/transparent/ProxyAdmin.sol";
+import { ProxyAdmin } from "mento-core-2.6.0-oz/contracts/proxy/transparent/ProxyAdmin.sol";
 
 interface IOwnableLite {
   function transferOwnership(address newOwner) external;

--- a/script/upgrades/MU09/deploy/MU09-Deploy-LockingProxyAdmin.sol
+++ b/script/upgrades/MU09/deploy/MU09-Deploy-LockingProxyAdmin.sol
@@ -12,7 +12,6 @@ interface IOwnableLite {
   function transferOwnership(address newOwner) external;
 }
 
-// yarn cgp:deploy -n celo -u MU09 -f -g mento
 contract MU09_Deploy_LockingProxyAdmin is Script {
   using Contracts for Contracts.Cache;
 

--- a/script/upgrades/MU09/deploy/MU09-Deploy-LockingProxyAdmin.sol
+++ b/script/upgrades/MU09/deploy/MU09-Deploy-LockingProxyAdmin.sol
@@ -6,16 +6,16 @@ import { console } from "forge-std-next/console.sol";
 import { Script } from "script/utils/mento/Script.sol";
 import { Chain as ChainLib } from "script/utils/mento/Chain.sol";
 import { Contracts } from "script/utils/mento/Contracts.sol";
-import { ProxyDeployerLib } from "mento-core-2.5.0/governance/deployers/ProxyDeployerLib.sol";
+import { ProxyDeployerLib } from "mento-core-2.6.0/governance/deployers/ProxyDeployerLib.sol";
 
 interface IOwnableLite {
-    function transferOwnership(address newOwner) external;
+  function transferOwnership(address newOwner) external;
 }
 
 contract MU09_Deploy_LockingProxyAdmin is Script {
   using Contracts for Contracts.Cache;
 
-  function run() public { 
+  function run() public {
     address mentoLabsMultisig = contracts.dependency("MentoLabsMultisig");
     require(mentoLabsMultisig != address(0), "MentoLabsMultisig address not found");
 


### PR DESCRIPTION
### Description

- Adds script to deploy a proxy admin for the locking contract along with a governance script + checks

### Other changes

- None

### Tested

- Executed deployment, cgp & checks on local fork
![image](https://github.com/user-attachments/assets/6b890e4d-985d-4af9-8a58-f65df0a87171)

### Related issues

- Fixes #240 

