### PR TITLE
fix: MU08 CELO return amounts

### DIFF
--- a/script/upgrades/MU08/MU08.md
+++ b/script/upgrades/MU08/MU08.md
@@ -41,7 +41,7 @@ Mento Governance contracts:
 
 - GovernanceFactory
 
-Steps to return of 80 Million CELO to Celo Governance:
+Steps to return of 82,406,987 CELO to Celo Governance:
 
 1. set and initialize Celo Custody Reserve
 2. add celo gov to custody reserve as other reserve address
@@ -49,8 +49,8 @@ Steps to return of 80 Million CELO to Celo Governance:
 4. add custody reserve as other reserve address to main reserve
 5. add celo gov as Spender on main reserve
 6. set celo spending ratio to 100% on main reserve
-7. transfer 80 Million CELO to custody reserve
-8. transfer 20 Million CELO from custody reserve to Celo gov
+7. transfer ~82.4M CELO to custody reserve
+8. transfer 20M CELO from custody reserve to Celo gov
 9. remove celo gov from main reserve spender list
 10. remove custody reserve from main reserve other reserve list
 11. transfer ownership of celo custody reserve to mento Gov

--- a/script/upgrades/MU08/MU08.sol
+++ b/script/upgrades/MU08/MU08.sol
@@ -261,9 +261,12 @@ contract MU08 is IMentoUpgrade, GovernanceScript {
   }
 
   function proposal_transferCeloToCustodyReserve() public {
-    require(80_000_000 * 1e18 <= IReserve(reserveProxy).getUnfrozenBalance(), "Not enough CELO in main reserve");
+    uint256 fullReturnAmount = 82_406_987 * 1e18;
+    uint256 firstReturnAmount = 20_000_000 * 1e18;
 
-    // transfer 80M CELO to custody reserve from main reserve
+    require(fullReturnAmount <= IReserve(reserveProxy).getUnfrozenBalance(), "Not enough CELO in main reserve");
+
+    // transfer ~82M CELO to custody reserve from main reserve
     transactions.push(
       ICeloGovernance.Transaction(
         0,
@@ -272,7 +275,7 @@ contract MU08 is IMentoUpgrade, GovernanceScript {
           IReserve(0).transferCollateralAsset.selector,
           CELOProxy,
           celoCustodyReserve,
-          80_000_000 * 1e18
+          fullReturnAmount
         )
       )
     );
@@ -286,7 +289,7 @@ contract MU08 is IMentoUpgrade, GovernanceScript {
           IReserve(0).transferCollateralAsset.selector,
           CELOProxy,
           celoGovernance,
-          20_000_000 * 1e18
+          firstReturnAmount
         )
       )
     );

--- a/script/upgrades/MU08/MU08.sol
+++ b/script/upgrades/MU08/MU08.sol
@@ -266,7 +266,7 @@ contract MU08 is IMentoUpgrade, GovernanceScript {
 
     require(fullReturnAmount <= IReserve(reserveProxy).getUnfrozenBalance(), "Not enough CELO in main reserve");
 
-    // transfer ~82M CELO to custody reserve from main reserve
+    // transfer ~82.4M CELO to custody reserve from main reserve
     transactions.push(
       ICeloGovernance.Transaction(
         0,

--- a/script/upgrades/MU08/MU08Checks.sol
+++ b/script/upgrades/MU08/MU08Checks.sol
@@ -191,18 +191,22 @@ contract MU08Checks is GovernanceScript, Test {
   }
 
   function verifyReturnOfCelo() public {
-    console.log("\n== Verifying return of 80M Celo: ==");
+    uint256 fullReturnAmount = 82_406_987 * 1e18;
+    uint256 firstReturnAmount = 20_000_000 * 1e18;
+    uint256 remainingReturnAmount = 62_406_987 * 1e18;
 
-    // Verify custody reserve balance is 60_000_000 CELO
+    console.log("\n== Verifying return of 82.4M Celo: ==");
+
+    // Verify custody reserve balance is 62_406_987 CELO
     uint256 balance = IERC20(CELOProxy).balanceOf(celoCustodyReserve);
-    require(balance == 60_000_000e18, "❗️❌ Custody reserve balance is not 60_000_000 CELO");
-    console.log("🟢 Custody reserve balance is 60_000_000 Celo");
+    require(balance == remainingReturnAmount, "❗️❌ Custody reserve balance is not 62.4M CELO");
+    console.log("🟢 Custody reserve balance is 62.4M Celo");
 
     // Verify initial CELO amount was transferred to Celo Governance
     uint256 celoGovernanceBalance = IERC20(CELOProxy).balanceOf(celoGovernance);
     // @dev can't do an exact check because Celo Governance already has some CELO
-    require(20_000_000e18 <= celoGovernanceBalance, "❗️❌ Celo Governance balance is less than 20_000_000 CELO");
-    console.log("🟢 Celo Governance balance is larger than 20_000_000 CELO");
+    require(firstReturnAmount <= celoGovernanceBalance, "❗️❌ Celo Governance balance is less than 20M CELO");
+    console.log("🟢 Celo Governance balance is larger than 20M CELO");
 
     // Verify custody reserve last spending day on collateral asset
     uint256 lastSpend = IReserve(celoCustodyReserve).collateralAssetLastSpendingDay(CELOProxy);
@@ -210,10 +214,14 @@ contract MU08Checks is GovernanceScript, Test {
 
     // Verify Celo governance can pull remaining CELO from custody reserve
     vm.prank(celoGovernance);
-    IReserve(celoCustodyReserve).transferCollateralAsset(CELOProxy, address(uint160(celoGovernance)), 60_000_000e18);
+    IReserve(celoCustodyReserve).transferCollateralAsset(
+      CELOProxy,
+      address(uint160(celoGovernance)),
+      remainingReturnAmount
+    );
     uint256 celoGovernanceBalanceAfter = IERC20(CELOProxy).balanceOf(celoGovernance);
     require(
-      celoGovernanceBalanceAfter == celoGovernanceBalance + 60_000_000e18,
+      celoGovernanceBalanceAfter == celoGovernanceBalance + remainingReturnAmount,
       "❗️❌ Celo Governance can't pull remaining CELO from custody reserve"
     );
     console.log("🟢 Celo Governance can pull remaining CELO from custody reserve");


### PR DESCRIPTION
### Description

This updates the amount of CELO that will be return in celo governance as part of MU08. We went with a rough number of ~80M CELO but the exact amount is `82,406,987`.

### Other changes

N/A

### Tested

Simulation is green on Alfajores