### PR TITLE
fix: update MU08 CELO return amount

### DIFF
--- a/script/upgrades/MU08/MU08.md
+++ b/script/upgrades/MU08/MU08.md
@@ -1,12 +1,12 @@
 ### MU08
 
-Transfer ownership of the MentoProtocol contracts to Mento Governance. Return of 80 Million CELO to Celo Governance.
+Transfer ownership of the MentoProtocol contracts to Mento Governance. Return of 85.9 Million CELO to Celo Governance
 
 Proposal Summary:
 
 - This proposal transfers ownership of the MentoProtocol contracts to Mento Governance. This will allow Mento token holders to own and manage the protocol.
 - Additionally it adds Reserve Multisig as an "Other Reserve Address" of onchain Reserve contract and removes old other reserve addresses.
-- In order to complete the governance transition the 80 Million CELO that was previously transferred to the mento reserve is returned to Celo Governance.
+- In order to complete the governance transition the 85.9 Million CELO that was previously transferred to the mento reserve is returned to Celo Governance.
 
 Contracts to Transfer Ownership:
 
@@ -41,7 +41,7 @@ Mento Governance contracts:
 
 - GovernanceFactory
 
-Steps to return of 82,406,987 CELO to Celo Governance:
+Steps to return of 85,941,499 CELO to Celo Governance:
 
 1. set and initialize Celo Custody Reserve
 2. add celo gov to custody reserve as other reserve address
@@ -49,7 +49,7 @@ Steps to return of 82,406,987 CELO to Celo Governance:
 4. add custody reserve as other reserve address to main reserve
 5. add celo gov as Spender on main reserve
 6. set celo spending ratio to 100% on main reserve
-7. transfer ~82.4M CELO to custody reserve
+7. transfer ~85.9M CELO to custody reserve
 8. transfer 20M CELO from custody reserve to Celo gov
 9. remove celo gov from main reserve spender list
 10. remove custody reserve from main reserve other reserve list

--- a/script/upgrades/MU08/MU08.sol
+++ b/script/upgrades/MU08/MU08.sol
@@ -265,12 +265,12 @@ contract MU08 is IMentoUpgrade, GovernanceScript {
   }
 
   function proposal_transferCeloToCustodyReserve() public {
-    uint256 fullReturnAmount = 82_406_987 * 1e18;
+    uint256 fullReturnAmount = 85941499340972869827370586; // 85.9M CELO
     uint256 firstReturnAmount = 20_000_000 * 1e18;
 
     require(fullReturnAmount <= IReserve(reserveProxy).getUnfrozenBalance(), "Not enough CELO in main reserve");
 
-    // transfer ~82.4M CELO to custody reserve from main reserve
+    // transfer ~85.9M CELO to custody reserve from main reserve
     transactions.push(
       ICeloGovernance.Transaction(
         0,

--- a/script/upgrades/MU08/MU08Checks.sol
+++ b/script/upgrades/MU08/MU08Checks.sol
@@ -191,16 +191,16 @@ contract MU08Checks is GovernanceScript, Test {
   }
 
   function verifyReturnOfCelo() public {
-    uint256 fullReturnAmount = 82_406_987 * 1e18;
+    uint256 fullReturnAmount = 85941499340972869827370586; // 85.9M CELO
     uint256 firstReturnAmount = 20_000_000 * 1e18;
-    uint256 remainingReturnAmount = 62_406_987 * 1e18;
+    uint256 remainingReturnAmount = 65941499340972869827370586; // 65.9M CELO
 
-    console.log("\n== Verifying return of 82.4M Celo: ==");
+    console.log("\n== Verifying return of 85.9M Celo: ==");
 
-    // Verify custody reserve balance is 62_406_987 CELO
+    // Verify custody reserve balance is ~65.9M CELO
     uint256 balance = IERC20(CELOProxy).balanceOf(celoCustodyReserve);
-    require(balance == remainingReturnAmount, "❗️❌ Custody reserve balance is not 62.4M CELO");
-    console.log("🟢 Custody reserve balance is 62.4M Celo");
+    require(balance == remainingReturnAmount, "❗️❌ Custody reserve balance is not 65.9M CELO");
+    console.log("🟢 Custody reserve balance is 65.9M Celo");
 
     // Verify initial CELO amount was transferred to Celo Governance
     uint256 celoGovernanceBalance = IERC20(CELOProxy).balanceOf(celoGovernance);


### PR DESCRIPTION
### Description

The previous CELO amount to be returned to the Celo community (`82_406_987`) didn't include the CELO that was sent to the Reserve via the Reserve bolstering mechanism, which was an additional 3.5M CELO. This updates the amount to 85.9M in total.

The additional CELO was taken from on-chain epoch rewards data, for a total sum of `3,534,512.340972869827370586` CELO.

### Other changes

N/A

### Tested

Simulation green on Mainnet.
