### PR TITLE
fix: split oracle migration into 2 proposals

### DIFF
--- a/script/upgrades/OracleMigration/OracleMigration.sol
+++ b/script/upgrades/OracleMigration/OracleMigration.sol
@@ -32,6 +32,8 @@ interface ISortedOracles {
 
   function getOracles(address) external returns (address[] memory);
 
+  function getRates(address rateFeedId) external returns (address[] memory, uint256[] memory, uint256[] memory);
+
   function setTokenReportExpiry(address, uint256) external;
 
   function getTokenReportExpirySeconds(address) external returns (uint256);
@@ -97,12 +99,6 @@ contract OracleMigration is IMentoUpgrade, GovernanceScript {
     require(transactions.length == 0, "buildProposal() should only be called once");
 
     address[] memory feedsToMigrate = config.feedsToMigrate();
-
-    // 1. Remove all oracles from the feeds, except for the redstone adapter
-    for (uint i = 0; i < feedsToMigrate.length; i++) {
-      address identifier = feedsToMigrate[i];
-      removeAllOracles(identifier);
-    }
 
     // 2. Whitelist the chainlink relayer for the chainlink powered feeds
     for (uint i = 0; i < feedsToMigrate.length; i++) {
@@ -202,29 +198,6 @@ contract OracleMigration is IMentoUpgrade, GovernanceScript {
           abi.encodeWithSelector(IBiPoolManager(0).createExchange.selector, newExchange)
         )
       );
-
-      if (i == 0) break;
-    }
-  }
-
-  function removeAllOracles(address rateFeedIdentifier) internal {
-    address[] memory oracles = ISortedOracles(sortedOracles).getOracles(rateFeedIdentifier);
-    bool isRedstonePowered = config.isRedstonePowered(rateFeedIdentifier);
-
-    if (isRedstonePowered) {
-      require(Arrays.contains(oracles, redstoneAdapter), "Redstone adapter not found on redstone powered feed");
-    }
-
-    for (uint i = oracles.length - 1; i >= 0; i--) {
-      if (oracles[i] != redstoneAdapter) {
-        transactions.push(
-          ICeloGovernance.Transaction({
-            value: 0,
-            destination: address(sortedOracles),
-            data: abi.encodeWithSelector(ISortedOracles(0).removeOracle.selector, rateFeedIdentifier, oracles[i], i)
-          })
-        );
-      }
 
       if (i == 0) break;
     }

--- a/script/upgrades/OracleMigration/OracleMigration.sol
+++ b/script/upgrades/OracleMigration/OracleMigration.sol
@@ -90,7 +90,7 @@ contract OracleMigration is IMentoUpgrade, GovernanceScript {
 
     vm.startBroadcast(Chain.deployerPrivateKey());
     {
-      createProposal(_transactions, "https://github.com/celo-org/governance/blob/main/CGPs/cgp-0184.md", governance);
+      createProposal(_transactions, "https://github.com/celo-org/governance/blob/main/CGPs/cgp-0186.md", governance);
     }
     vm.stopBroadcast();
   }

--- a/script/upgrades/OracleRemoval/OracleRemoval.sol
+++ b/script/upgrades/OracleRemoval/OracleRemoval.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// solhint-disable func-name-mixedcase, contract-name-camelcase, function-max-lines, var-name-mixedcase
+pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
+
+import { GovernanceScript } from "script/utils/Script.sol";
+import { console2 as console } from "celo-foundry/Test.sol";
+import { Contracts } from "script/utils/Contracts.sol";
+import { Chain } from "script/utils/Chain.sol";
+import { Arrays } from "script/utils/Arrays.sol";
+
+import { IChainlinkRelayerFactory } from "mento-core-2.5.0/interfaces/IChainlinkRelayerFactory.sol";
+import { IChainlinkRelayer } from "mento-core-2.5.0/interfaces/IChainlinkRelayer.sol";
+import { IBiPoolManager, FixidityLib } from "mento-core-2.5.0/interfaces/IBiPoolManager.sol";
+
+import { IMentoUpgrade, ICeloGovernance } from "script/interfaces/IMentoUpgrade.sol";
+
+import { ISortedOracles } from "../OracleMigration/OracleMigration.sol";
+import { OracleMigrationConfig } from "../OracleMigration/Config.sol";
+
+contract OracleRemoval is IMentoUpgrade, GovernanceScript {
+  using Contracts for Contracts.Cache;
+  bool public hasChecks = true;
+  ICeloGovernance.Transaction[] private transactions;
+
+  OracleMigrationConfig private config;
+
+  address private redstoneAdapter;
+  ISortedOracles private sortedOracles;
+
+  function prepare() public {
+    loadDeployedContracts();
+    setAddresses();
+  }
+
+  function loadDeployedContracts() public {
+    contracts.loadSilent("MU01-00-Create-Proxies", "latest");
+    contracts.loadSilent("MU07-Deploy-ChainlinkRelayerFactory", "latest");
+  }
+
+  function setAddresses() public {
+    config = new OracleMigrationConfig();
+    config.load();
+
+    sortedOracles = ISortedOracles(contracts.celoRegistry("SortedOracles"));
+    redstoneAdapter = contracts.dependency("RedstoneAdapter");
+  }
+
+  function run() public {
+    prepare();
+
+    address governance = contracts.celoRegistry("Governance");
+    ICeloGovernance.Transaction[] memory _transactions = buildProposal();
+
+    vm.startBroadcast(Chain.deployerPrivateKey());
+    {
+      createProposal(_transactions, "https://github.com/celo-org/governance/blob/main/CGPs/cgp-0184.md", governance);
+    }
+    vm.stopBroadcast();
+  }
+
+  function buildProposal() public returns (ICeloGovernance.Transaction[] memory) {
+    require(transactions.length == 0, "buildProposal() should only be called once");
+
+    address[] memory feedsToMigrate = config.feedsToMigrate();
+
+    // 1. Remove all oracles from the feeds, except for the redstone adapter
+    for (uint i = 0; i < feedsToMigrate.length; i++) {
+      address identifier = feedsToMigrate[i];
+      removeAllOracles(identifier);
+    }
+
+    return transactions;
+  }
+
+  function removeAllOracles(address rateFeedIdentifier) internal {
+    address[] memory oracles = ISortedOracles(sortedOracles).getOracles(rateFeedIdentifier);
+    bool isRedstonePowered = config.isRedstonePowered(rateFeedIdentifier);
+
+    if (isRedstonePowered) {
+      require(Arrays.contains(oracles, redstoneAdapter), "Redstone adapter not found on redstone powered feed");
+    }
+
+    for (uint i = oracles.length - 1; i >= 0; i--) {
+      if (oracles[i] != redstoneAdapter) {
+        transactions.push(
+          ICeloGovernance.Transaction({
+            value: 0,
+            destination: address(sortedOracles),
+            data: abi.encodeWithSelector(ISortedOracles(0).removeOracle.selector, rateFeedIdentifier, oracles[i], i)
+          })
+        );
+      }
+
+      if (i == 0) break;
+    }
+  }
+}

--- a/script/upgrades/OracleRemoval/OracleRemovalChecks.sol
+++ b/script/upgrades/OracleRemoval/OracleRemovalChecks.sol
@@ -51,7 +51,6 @@ contract OracleRemovalChecks is GovernanceScript, Test {
     for (uint i = 0; i < allFeeds.length; i++) {
       address identifier = allFeeds[i];
       address[] memory whitelisted = sortedOracles.getOracles(identifier);
-      uint256 actualExpiry = sortedOracles.tokenReportExpirySeconds(identifier);
 
       if (config.isRedstonePowered(identifier)) {
         require(whitelisted.length == 1, "❌ Expected exactly 1 oracle to be whitelisted");

--- a/script/upgrades/OracleRemoval/OracleRemovalChecks.sol
+++ b/script/upgrades/OracleRemoval/OracleRemovalChecks.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// solhint-disable var-name-mixedcase, func-name-mixedcase
+pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
+
+import { Test } from "forge-std/Test.sol";
+import { console2 } from "forge-std/console2.sol";
+import { Contracts } from "script/utils/Contracts.sol";
+import { Chain } from "script/utils/Chain.sol";
+import { Arrays } from "script/utils/Arrays.sol";
+import { GovernanceScript } from "script/utils/Script.sol";
+
+import { IChainlinkRelayerFactory } from "mento-core-2.5.0/interfaces/IChainlinkRelayerFactory.sol";
+import { IChainlinkRelayer } from "mento-core-2.5.0/interfaces/IChainlinkRelayer.sol";
+import { IBiPoolManager, FixidityLib } from "mento-core-2.5.0/interfaces/IBiPoolManager.sol";
+
+import { ISortedOracles } from "../OracleMigration/OracleMigration.sol";
+import { OracleMigrationConfig } from "../OracleMigration/Config.sol";
+
+contract OracleRemovalChecks is GovernanceScript, Test {
+  using Contracts for Contracts.Cache;
+
+  OracleMigrationConfig private config;
+
+  ISortedOracles private sortedOracles;
+
+  address private redstoneAdapter;
+
+  function prepare() public {
+    contracts.loadSilent("MU01-00-Create-Proxies", "latest");
+
+    config = new OracleMigrationConfig();
+    config.load();
+
+    sortedOracles = ISortedOracles(contracts.celoRegistry("SortedOracles"));
+    redstoneAdapter = contracts.dependency("RedstoneAdapter");
+  }
+
+  function run() public {
+    prepare();
+    console2.log("\n");
+
+    checkSortedOraclesConfig();
+    console2.log("✅ All checks passed\n");
+  }
+
+  function checkSortedOraclesConfig() internal {
+    console2.log("====🔍 Checking if sortedOracles is correctly configured...====");
+
+    address[] memory allFeeds = Arrays.merge(config.feedsToMigrate(), config.additionalRelayersToWhitelist());
+    for (uint i = 0; i < allFeeds.length; i++) {
+      address identifier = allFeeds[i];
+      address[] memory whitelisted = sortedOracles.getOracles(identifier);
+      uint256 actualExpiry = sortedOracles.tokenReportExpirySeconds(identifier);
+
+      if (config.isRedstonePowered(identifier)) {
+        require(whitelisted.length == 1, "❌ Expected exactly 1 oracle to be whitelisted");
+        require(whitelisted[0] == redstoneAdapter, "❌ Expected redstone adapter to be whitelisted");
+        console2.log("✅ Redstone adapter is whitelisted on feed %s", config.getFeedName(identifier));
+      } else {
+        require(whitelisted.length == 0, "❌ Expected no oracles to be whitelisted on chainlink powered feed");
+        console2.log("✅ No oracles are whitelisted on chainlink powered feed %s", config.getFeedName(identifier));
+      }
+    }
+    console2.log("🤑 All %d feeds were updated correctly\n", allFeeds.length);
+  }
+}


### PR DESCRIPTION
### Description

Unfortunately the full migration proposal exceeded the block gas limit (it seems to have consumed ~37M gas), so we decided to split it into two proposals:

1) Oracle removal proposal, where we exclusively remove all whitelisted addresses from SortedOracles. This is the most gas consuming part as it contains 128 transactions.

2) The actual migration proposal, in which we whitelist the new relayers, set the tokenExpiry and re-create the exchanges.

We will propose both of them roughly at the same time as Oracle Migration pt. 1 and pt.2 so that people can see them as a bundle and vote on them roughly together.

### Other changes

N/A

### Tested

The simulations for the Oracle removal proposal
`yarn cgp -n celo -u OracleRemoval -g celo -s`

and the Oracle migration
`yarn cgp -n celo -u OracleMigration -g celo -s`

are both green
