### PR TITLE
feat: Pools restructuring CGP

### DIFF
--- a/script/upgrades/PoolRestructuring/CfgHelper.sol
+++ b/script/upgrades/PoolRestructuring/CfgHelper.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// solhint-disable func-name-mixedcase, contract-name-camelcase, function-max-lines, var-name-mixedcase
+pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
+
+import { GovernanceScript } from "script/utils/Script.sol";
+
+contract CfgHelper is GovernanceScript {
+  address public CELOProxy;
+  address public cUSDProxy;
+  address public cEURProxy;
+  address public cBRLProxy;
+  address public eXOFProxy;
+  address public cKESProxy;
+  address public cCADProxy;
+  address public cAUDProxy;
+  address public cCHFProxy;
+  address public cGBPProxy;
+  address public cZARProxy;
+  address public cJPYProxy;
+  address public cNGNProxy;
+  address public PUSOProxy;
+  address public cCOPProxy;
+  address public cGHSProxy;
+
+  address public nativeUSDCProxy;
+  address public nativeUSDTProxy;
+  address public axlUSDCProxy;
+  address public axlEUROCProxy;
+
+  mapping(address => string) public rateFeedIdToName;
+
+  function load() public {
+    contracts.loadSilent("cKES-00-Create-Proxies", "latest");
+    contracts.loadSilent("eXOF-00-Create-Proxies", "latest");
+    contracts.loadSilent("FX00-00-Deploy-Proxys", "latest");
+    contracts.loadSilent("FX02-00-Deploy-Proxys", "latest");
+    contracts.loadSilent("PUSO-00-Create-Proxies", "latest");
+    contracts.loadSilent("cCOP-00-Create-Proxies", "latest");
+    contracts.loadSilent("cGHS-00-Deploy-Proxy", "latest");
+
+    CELOProxy = contracts.celoRegistry("GoldToken");
+    cUSDProxy = contracts.celoRegistry("StableToken");
+    cEURProxy = contracts.celoRegistry("StableTokenEUR");
+    cBRLProxy = contracts.celoRegistry("StableTokenBRL");
+    eXOFProxy = contracts.deployed("StableTokenXOFProxy");
+    cKESProxy = contracts.deployed("StableTokenKESProxy");
+    cCADProxy = contracts.deployed("StableTokenCADProxy");
+    cAUDProxy = contracts.deployed("StableTokenAUDProxy");
+    cCHFProxy = contracts.deployed("StableTokenCHFProxy");
+    cGBPProxy = contracts.deployed("StableTokenGBPProxy");
+    cZARProxy = contracts.deployed("StableTokenZARProxy");
+    cJPYProxy = contracts.deployed("StableTokenJPYProxy");
+    cNGNProxy = contracts.deployed("StableTokenNGNProxy");
+    PUSOProxy = contracts.deployed("StableTokenPHPProxy");
+    cCOPProxy = contracts.deployed("StableTokenCOPProxy");
+    cGHSProxy = contracts.deployed("StableTokenGHSProxy");
+
+    nativeUSDCProxy = contracts.dependency("NativeUSDC");
+    nativeUSDTProxy = contracts.dependency("NativeUSDT");
+    axlUSDCProxy = contracts.dependency("BridgedUSDC");
+    axlEUROCProxy = contracts.dependency("BridgedEUROC");
+
+    setFeedsNames();
+  }
+
+  function setFeedsNames() internal {
+    rateFeedIdToName[cUSDProxy] = "CELO/USD";
+    rateFeedIdToName[cEURProxy] = "CELO/EUR";
+    rateFeedIdToName[cBRLProxy] = "CELO/BRL";
+    rateFeedIdToName[eXOFProxy] = "CELO/XOF";
+    rateFeedIdToName[cKESProxy] = "CELO/KES";
+    rateFeedIdToName[toRateFeedId("USDCUSD")] = "USDC/USD";
+    rateFeedIdToName[toRateFeedId("USDCEUR")] = "USDC/EUR";
+    rateFeedIdToName[toRateFeedId("USDCBRL")] = "USDC/BRL";
+    rateFeedIdToName[toRateFeedId("EUROCEUR")] = "EUROC/EUR";
+    rateFeedIdToName[toRateFeedId("EUROCXOF")] = "EUROC/XOF";
+    rateFeedIdToName[toRateFeedId("EURXOF")] = "EUR/XOF";
+    rateFeedIdToName[toRateFeedId("KESUSD")] = "KES/USD";
+    rateFeedIdToName[toRateFeedId("USDTUSD")] = "USDT/USD";
+    rateFeedIdToName[toRateFeedId("relayed:EURUSD")] = "EUR/USD";
+    rateFeedIdToName[toRateFeedId("relayed:BRLUSD")] = "BRL/USD";
+    rateFeedIdToName[toRateFeedId("relayed:XOFUSD")] = "XOF/USD";
+    rateFeedIdToName[toRateFeedId("relayed:PHPUSD")] = "PHP/USD";
+    rateFeedIdToName[toRateFeedId("relayed:CADUSD")] = "CAD/USD";
+    rateFeedIdToName[toRateFeedId("relayed:AUDUSD")] = "AUD/USD";
+    rateFeedIdToName[toRateFeedId("relayed:JPYUSD")] = "JPY/USD";
+    rateFeedIdToName[toRateFeedId("relayed:NGNUSD")] = "NGN/USD";
+    rateFeedIdToName[toRateFeedId("relayed:COPUSD")] = "COP/USD";
+    rateFeedIdToName[toRateFeedId("relayed:GHSUSD")] = "GHS/USD";
+    rateFeedIdToName[toRateFeedId("relayed:CHFUSD")] = "CHF/USD";
+    rateFeedIdToName[toRateFeedId("relayed:ZARUSD")] = "ZAR/USD";
+    rateFeedIdToName[toRateFeedId("relayed:GBPUSD")] = "GBP/USD";
+  }
+
+  function getFeedName(address rateFeedId) public view returns (string memory) {
+    return rateFeedIdToName[rateFeedId];
+  }
+}

--- a/script/upgrades/PoolRestructuring/NewPoolsCfg.sol
+++ b/script/upgrades/PoolRestructuring/NewPoolsCfg.sol
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// solhint-disable func-name-mixedcase, contract-name-camelcase, function-max-lines, var-name-mixedcase
+pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
+
+import { Chain } from "script/utils/Chain.sol";
+import { Config } from "script/utils/Config.sol";
+import { Contracts } from "script/utils/Contracts.sol";
+import { Arrays } from "script/utils/Arrays.sol";
+import { FixidityLib } from "script/utils/FixidityLib.sol";
+
+library NewPoolsCfg {
+  using FixidityLib for FixidityLib.Fraction;
+  using Contracts for Contracts.Cache;
+
+  struct NewPools {
+    Config.Pool cUSDcEUR;
+    Config.Pool cUSDcREAL;
+    Config.Pool cUSDeXOF;
+    Config.RateFeed[] rateFeedsConfig;
+    Config.Pool[] pools;
+  }
+
+  function get(Contracts.Cache storage contracts) internal returns (NewPools memory config) {
+    config.pools = new Config.Pool[](3);
+    config.pools[0] = config.cUSDcEUR = cUSDcEUR_PoolConfig(contracts);
+    config.pools[1] = config.cUSDcREAL = cUSDcREAL_PoolConfig(contracts);
+    config.pools[2] = config.cUSDeXOF = cUSDeXOF_PoolConfig(contracts);
+
+    config.rateFeedsConfig = newPoolsRateFeedConfig();
+  }
+
+  function newPoolsRateFeedConfig() internal pure returns (Config.RateFeed[] memory rateFeedConfig) {
+    address[] memory rateFeedIDs = new address[](3);
+    rateFeedIDs[0] = Config.rateFeedID("relayed:EURUSD");
+    rateFeedIDs[1] = Config.rateFeedID("relayed:BRLUSD");
+    rateFeedIDs[2] = Config.rateFeedID("relayed:XOFUSD");
+
+    Config.RateFeed[] memory rateFeedsConfig = new Config.RateFeed[](3);
+    for (uint256 i = 0; i < rateFeedIDs.length; i++) {
+      Config.RateFeed memory cfg;
+      cfg.rateFeedID = rateFeedIDs[i];
+      cfg.medianDeltaBreaker0 = Config.MedianDeltaBreaker({
+        enabled: true,
+        threshold: FixidityLib.newFixedFraction(4, 100), // 4%
+        cooldown: 15 minutes,
+        smoothingFactor: FixidityLib.newFixedFraction(5, 1000).unwrap() // 0.005
+      });
+      rateFeedsConfig[i] = cfg;
+    }
+
+    return rateFeedsConfig;
+  }
+
+  function cUSDcEUR_PoolConfig(
+    Contracts.Cache storage contracts
+  ) internal view returns (Config.Pool memory poolConfig) {
+    poolConfig = Config.Pool({
+      asset0: contracts.celoRegistry("StableToken"),
+      asset1: contracts.celoRegistry("StableTokenEUR"),
+      isConstantSum: true,
+      spread: FixidityLib.newFixedFraction(5, 1000), // 0.5%, in line with current DT of chainlink feed
+      referenceRateResetFrequency: 6 minutes,
+      minimumReports: 1,
+      stablePoolResetSize: 10_000_000 * 1e18,
+      referenceRateFeedID: Config.rateFeedID("relayed:EURUSD"),
+      asset0limits: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 100_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 500_000,
+        enabledGlobal: true,
+        limitGlobal: 2_500_000
+      }),
+      asset1limits: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 100_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 500_000,
+        enabledGlobal: true,
+        limitGlobal: 2_500_000
+      })
+    });
+  }
+
+  function cUSDcREAL_PoolConfig(
+    Contracts.Cache storage contracts
+  ) internal view returns (Config.Pool memory poolConfig) {
+    poolConfig = Config.Pool({
+      asset0: contracts.celoRegistry("StableToken"),
+      asset1: contracts.celoRegistry("StableTokenBRL"),
+      isConstantSum: true,
+      spread: FixidityLib.newFixedFraction(3, 1000), // 0.3%, in line with current DT of chainlink feed
+      referenceRateResetFrequency: 6 minutes,
+      minimumReports: 1,
+      stablePoolResetSize: 10_000_000 * 1e18,
+      referenceRateFeedID: Config.rateFeedID("relayed:BRLUSD"),
+      asset0limits: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 100_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 500_000,
+        enabledGlobal: true,
+        limitGlobal: 2_500_000
+      }),
+      // 1 USD ≈ 5 BRL
+      asset1limits: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 500_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 2_500_000,
+        enabledGlobal: true,
+        limitGlobal: 12_500_000
+      })
+    });
+  }
+
+  function cUSDeXOF_PoolConfig(
+    Contracts.Cache storage contracts
+  ) internal view returns (Config.Pool memory poolConfig) {
+    poolConfig = Config.Pool({
+      asset0: contracts.celoRegistry("StableToken"),
+      asset1: contracts.deployed("StableTokenXOFProxy"),
+      isConstantSum: true,
+      spread: FixidityLib.newFixedFraction(2, 100), // 2%, in line with current DT of chainlink feed
+      referenceRateResetFrequency: 6 minutes,
+      minimumReports: 1,
+      stablePoolResetSize: 10_000_000 * 1e18,
+      referenceRateFeedID: Config.rateFeedID("relayed:XOFUSD"),
+      asset0limits: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 50_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 250_000,
+        enabledGlobal: true,
+        limitGlobal: 1_000_000
+      }),
+      // 1 USD ≈ 555 XOF
+      asset1limits: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 27_750_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 138_750_000,
+        enabledGlobal: true,
+        limitGlobal: 555_000_000
+      })
+    });
+  }
+}

--- a/script/upgrades/PoolRestructuring/PoolRestructuring.sol
+++ b/script/upgrades/PoolRestructuring/PoolRestructuring.sol
@@ -1,0 +1,424 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// solhint-disable func-name-mixedcase, contract-name-camelcase, function-max-lines, var-name-mixedcase
+pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
+
+import { GovernanceScript } from "script/utils/Script.sol";
+import { console2 as console } from "celo-foundry/Test.sol";
+import { Contracts } from "script/utils/Contracts.sol";
+import { Chain } from "script/utils/Chain.sol";
+import { Arrays } from "script/utils/Arrays.sol";
+
+import { Broker } from "mento-core-2.5.0/swap/Broker.sol";
+import { IBiPoolManager, FixidityLib } from "mento-core-2.5.0/interfaces/IBiPoolManager.sol";
+import { BreakerBox } from "mento-core-2.5.0/oracles/BreakerBox.sol";
+import { MedianDeltaBreaker } from "mento-core-2.5.0/oracles/breakers/MedianDeltaBreaker.sol";
+import { ValueDeltaBreaker } from "mento-core-2.5.0/oracles/breakers/ValueDeltaBreaker.sol";
+import { TradingLimits } from "mento-core-2.5.0/libraries/TradingLimits.sol";
+import { IPricingModule } from "mento-core-2.5.0/interfaces/IPricingModule.sol";
+
+import { IMentoUpgrade, ICeloGovernance } from "script/interfaces/IMentoUpgrade.sol";
+
+import { Config } from "script/utils/Config.sol";
+import { NewPoolsCfg } from "./NewPoolsCfg.sol";
+
+import { CfgHelper } from "script/upgrades/PoolRestructuring/CfgHelper.sol";
+import { PoolsCleanupCfg } from "script/upgrades/PoolRestructuring/PoolsCleanupCfg.sol";
+import { TradingLimitsCfg } from "script/upgrades/PoolRestructuring/TradingLimitsCfg.sol";
+import { ValueDeltaBreakerCfg } from "script/upgrades/PoolRestructuring/ValueDeltaBreakerCfg.sol";
+
+contract PoolRestructuring is IMentoUpgrade, GovernanceScript {
+  using TradingLimits for TradingLimits.Config;
+  using Contracts for Contracts.Cache;
+
+  bool public hasChecks = true;
+  ICeloGovernance.Transaction[] private transactions;
+
+  CfgHelper private cfgHelper;
+  PoolsCleanupCfg private poolsCleanupCfg;
+  TradingLimitsCfg private tradingLimitsCfg;
+  ValueDeltaBreakerCfg private valueDeltaBreakerCfg;
+
+  address private brokerProxy;
+  address private biPoolManagerProxy;
+  address private breakerBox;
+  address private medianDeltaBreaker;
+  address private valueDeltaBreaker;
+
+  mapping(address => bytes32) public referenceRateFeedIDToExchangeId;
+
+  function prepare() public {
+    loadDeployedContracts();
+    setAddresses();
+    setExchangeIds();
+  }
+
+  function loadDeployedContracts() public {
+    contracts.loadSilent("MU01-00-Create-Proxies", "latest");
+    contracts.loadSilent("MU01-01-Create-Nonupgradeable-Contracts", "latest");
+    contracts.loadSilent("MU03-01-Create-Nonupgradeable-Contracts");
+    contracts.loadSilent("eXOF-00-Create-Proxies", "latest");
+  }
+
+  function setAddresses() public {
+    cfgHelper = new CfgHelper();
+    cfgHelper.load();
+
+    poolsCleanupCfg = new PoolsCleanupCfg(cfgHelper);
+    tradingLimitsCfg = new TradingLimitsCfg(cfgHelper);
+    valueDeltaBreakerCfg = new ValueDeltaBreakerCfg();
+
+    brokerProxy = contracts.deployed("BrokerProxy");
+    biPoolManagerProxy = contracts.deployed("BiPoolManagerProxy");
+    breakerBox = contracts.deployed("BreakerBox");
+    medianDeltaBreaker = contracts.deployed("MedianDeltaBreaker");
+    valueDeltaBreaker = contracts.deployed("ValueDeltaBreaker");
+  }
+
+  function setExchangeIds() public {
+    IBiPoolManager biPoolManager = IBiPoolManager(biPoolManagerProxy);
+    bytes32[] memory exchangeIds = biPoolManager.getExchangeIds();
+
+    for (uint256 i = 0; i < exchangeIds.length; i++) {
+      bytes32 exchangeId = exchangeIds[i];
+      IBiPoolManager.PoolExchange memory currentExchange = biPoolManager.getPoolExchange(exchangeId);
+      referenceRateFeedIDToExchangeId[currentExchange.config.referenceRateFeedID] = exchangeId;
+    }
+
+    NewPoolsCfg.NewPools memory newPoolsCfg = NewPoolsCfg.get(contracts);
+    for (uint i = 0; i < newPoolsCfg.pools.length; i++) {
+      referenceRateFeedIDToExchangeId[newPoolsCfg.pools[i].referenceRateFeedID] = getExchangeId(
+        newPoolsCfg.pools[i].asset0,
+        newPoolsCfg.pools[i].asset1,
+        newPoolsCfg.pools[i].isConstantSum
+      );
+    }
+  }
+
+  function run() public {
+    prepare();
+
+    address governance = contracts.celoRegistry("Governance");
+    ICeloGovernance.Transaction[] memory _transactions = buildProposal();
+
+    vm.startBroadcast(Chain.deployerPrivateKey());
+    {
+      createProposal(_transactions, "TODO", governance);
+    }
+    vm.stopBroadcast();
+  }
+
+  function buildProposal() public returns (ICeloGovernance.Transaction[] memory) {
+    require(transactions.length == 0, "buildProposal() should only be called once");
+
+    // 1. Delete some pools, and re-create some of them with a newly proposed spread
+    deleteAndRecreatePoolsWithNewSpread();
+
+    // 2. Update the value delta breakers threshold on some pools
+    updateValueDeltaBreakersThreshold();
+
+    // 3. Update the trading limits on some pools
+    updateTradingLimits();
+
+    // 4. Create cUSD/cEUR, cUSD/cREAL and cUSD/eXOF pools
+    createNewPools();
+
+    return transactions;
+  }
+
+  function deleteAndRecreatePoolsWithNewSpread() internal {
+    IBiPoolManager biPoolManager = IBiPoolManager(biPoolManagerProxy);
+    bytes32[] memory exchangeIds = biPoolManager.getExchangeIds();
+
+    uint256 deletions = 0;
+    uint256 creations = 0;
+    for (uint256 i = exchangeIds.length - 1; i >= 0; i--) {
+      bytes32 exchangeId = exchangeIds[i];
+      IBiPoolManager.PoolExchange memory currentExchange = biPoolManager.getPoolExchange(exchangeId);
+
+      if (!poolsCleanupCfg.shouldBeDeleted(currentExchange)) {
+        continue;
+      }
+
+      deletions++;
+      transactions.push(
+        ICeloGovernance.Transaction(
+          0,
+          biPoolManagerProxy,
+          abi.encodeWithSelector(IBiPoolManager(0).destroyExchange.selector, exchangeId, i)
+        )
+      );
+
+      if (poolsCleanupCfg.shouldRecreateWithNewSpread(currentExchange)) {
+        creations++;
+
+        IBiPoolManager.PoolExchange memory newExchange = poolsCleanupCfg.getPoolCfgWithNewSpread(currentExchange);
+        transactions.push(
+          ICeloGovernance.Transaction(
+            0,
+            biPoolManagerProxy,
+            abi.encodeWithSelector(IBiPoolManager(0).createExchange.selector, newExchange)
+          )
+        );
+      }
+
+      if (i == 0) break;
+    }
+
+    require(
+      deletions == poolsCleanupCfg.poolsToDelete().length,
+      "❌ Number of deleted pools txs does not match expected"
+    );
+    require(
+      creations == poolsCleanupCfg.spreadOverrides().length,
+      "❌ Number of created pools txs does not match expected"
+    );
+  }
+
+  function updateValueDeltaBreakersThreshold() internal {
+    ValueDeltaBreakerCfg.Override[] memory overrides = valueDeltaBreakerCfg.valueDeltaBreakerOverrides();
+
+    for (uint256 i = 0; i < overrides.length; i++) {
+      uint256 currentThreshold = ValueDeltaBreaker(valueDeltaBreaker).rateChangeThreshold(overrides[i].rateFeedId);
+      require(currentThreshold == overrides[i].currentThreshold, "❌ Current threshold mismatch");
+    }
+
+    address[] memory rateFeedIds = Arrays.addresses(overrides[0].rateFeedId, overrides[1].rateFeedId);
+    uint256[] memory newThresholds = Arrays.uints(overrides[0].targetThreshold, overrides[1].targetThreshold);
+
+    transactions.push(
+      ICeloGovernance.Transaction(
+        0,
+        valueDeltaBreaker,
+        abi.encodeWithSelector(ValueDeltaBreaker(0).setRateChangeThresholds.selector, rateFeedIds, newThresholds)
+      )
+    );
+  }
+
+  function updateTradingLimits() internal {
+    TradingLimitsCfg.Override[] memory overrides = tradingLimitsCfg.tradingLimitsOverrides();
+
+    for (uint256 i = 0; i < overrides.length; i++) {
+      bytes32 exchangeId = referenceRateFeedIDToExchangeId[overrides[i].referenceRateFeedID];
+      require(exchangeId != bytes32(0), "❌ Exchange ID not found for trading limits override");
+
+      bytes32 limit0Id = exchangeId ^ bytes32(uint256(uint160(overrides[i].asset0)));
+
+      // update the trading limits on asset0 of the pool
+      transactions.push(
+        ICeloGovernance.Transaction(
+          0,
+          brokerProxy,
+          abi.encodeWithSelector(
+            Broker(0).configureTradingLimit.selector,
+            exchangeId,
+            overrides[i].asset0,
+            TradingLimits.Config({
+              timestep0: overrides[i].asset0Config.timeStep0,
+              timestep1: overrides[i].asset0Config.timeStep1,
+              limit0: overrides[i].asset0Config.limit0,
+              limit1: overrides[i].asset0Config.limit1,
+              limitGlobal: overrides[i].asset0Config.limitGlobal,
+              flags: Config.tradingLimitConfigToFlag(overrides[i].asset0Config)
+            })
+          )
+        )
+      );
+
+      // update trading limits on asset1 of the pool
+      transactions.push(
+        ICeloGovernance.Transaction(
+          0,
+          brokerProxy,
+          abi.encodeWithSelector(
+            Broker(0).configureTradingLimit.selector,
+            exchangeId,
+            overrides[i].asset1,
+            TradingLimits.Config({
+              timestep0: overrides[i].asset1Config.timeStep0,
+              timestep1: overrides[i].asset1Config.timeStep1,
+              limit0: overrides[i].asset1Config.limit0,
+              limit1: overrides[i].asset1Config.limit1,
+              limitGlobal: overrides[i].asset1Config.limitGlobal,
+              flags: Config.tradingLimitConfigToFlag(overrides[i].asset1Config)
+            })
+          )
+        )
+      );
+    }
+  }
+
+  function createNewPools() internal {
+    NewPoolsCfg.NewPools memory newPoolsCfg = NewPoolsCfg.get(contracts);
+
+    for (uint256 i = 0; i < newPoolsCfg.pools.length; i++) {
+      proposal_createExchange(newPoolsCfg.pools[i]);
+      proposal_configureTradingLimits(newPoolsCfg.pools[i]);
+    }
+
+    for (uint256 i = 0; i < newPoolsCfg.rateFeedsConfig.length; i++) {
+      proosal_configureBreakerBox(newPoolsCfg.rateFeedsConfig[i]);
+      proposal_configureMedianDeltaBreaker(newPoolsCfg.rateFeedsConfig[i]);
+    }
+  }
+
+  /**
+   * @notice Creates the exchange for the new pool.
+   */
+  function proposal_createExchange(Config.Pool memory pool) private {
+    IPricingModule constantProduct = IPricingModule(contracts.deployed("ConstantProductPricingModule"));
+    IPricingModule constantSum = IPricingModule(contracts.deployed("ConstantSumPricingModule"));
+
+    IBiPoolManager.PoolExchange memory poolExchange = IBiPoolManager.PoolExchange({
+      asset0: pool.asset0,
+      asset1: pool.asset1,
+      pricingModule: pool.isConstantSum ? constantSum : constantProduct,
+      bucket0: 0,
+      bucket1: 0,
+      lastBucketUpdate: 0,
+      config: IBiPoolManager.PoolConfig({
+        spread: FixidityLib.wrap(pool.spread.unwrap()),
+        referenceRateFeedID: pool.referenceRateFeedID,
+        referenceRateResetFrequency: pool.referenceRateResetFrequency,
+        minimumReports: pool.minimumReports,
+        stablePoolResetSize: pool.stablePoolResetSize
+      })
+    });
+
+    transactions.push(
+      ICeloGovernance.Transaction(
+        0,
+        biPoolManagerProxy,
+        abi.encodeWithSelector(IBiPoolManager(0).createExchange.selector, poolExchange)
+      )
+    );
+  }
+
+  /**
+   * @notice Configures the trading limits for the new pool.
+   */
+  function proposal_configureTradingLimits(Config.Pool memory pool) private {
+    bytes32 exchangeId = referenceRateFeedIDToExchangeId[pool.referenceRateFeedID];
+
+    // Set the trading limit for asset0 of the pool
+    transactions.push(
+      ICeloGovernance.Transaction(
+        0,
+        brokerProxy,
+        abi.encodeWithSelector(
+          Broker(0).configureTradingLimit.selector,
+          exchangeId,
+          pool.asset0,
+          TradingLimits.Config({
+            timestep0: pool.asset0limits.timeStep0,
+            timestep1: pool.asset0limits.timeStep1,
+            limit0: pool.asset0limits.limit0,
+            limit1: pool.asset0limits.limit1,
+            limitGlobal: pool.asset0limits.limitGlobal,
+            flags: Config.tradingLimitConfigToFlag(pool.asset0limits)
+          })
+        )
+      )
+    );
+
+    // Set the trading limit for asset1 of the pool
+    transactions.push(
+      ICeloGovernance.Transaction(
+        0,
+        brokerProxy,
+        abi.encodeWithSelector(
+          Broker(0).configureTradingLimit.selector,
+          exchangeId,
+          pool.asset1,
+          TradingLimits.Config({
+            timestep0: pool.asset1limits.timeStep0,
+            timestep1: pool.asset1limits.timeStep1,
+            limit0: pool.asset1limits.limit0,
+            limit1: pool.asset1limits.limit1,
+            limitGlobal: pool.asset1limits.limitGlobal,
+            flags: Config.tradingLimitConfigToFlag(pool.asset1limits)
+          })
+        )
+      )
+    );
+  }
+
+  /**
+   * @notice Configures the breaker box for the specified rate feed.
+   */
+  function proosal_configureBreakerBox(Config.RateFeed memory rateFeed) private {
+    // Add the new rate feed to breaker box
+    transactions.push(
+      ICeloGovernance.Transaction(
+        0,
+        breakerBox,
+        abi.encodeWithSelector(BreakerBox(0).addRateFeed.selector, rateFeed.rateFeedID)
+      )
+    );
+
+    // Enable Median Delta Breaker for rate feed
+    if (rateFeed.medianDeltaBreaker0.enabled) {
+      // Reset the median value for this rateFeed, if we somehow have one set
+      if (MedianDeltaBreaker(medianDeltaBreaker).medianRatesEMA(rateFeed.rateFeedID) != 0) {
+        transactions.push(
+          ICeloGovernance.Transaction(
+            0,
+            medianDeltaBreaker,
+            abi.encodeWithSelector(MedianDeltaBreaker(0).resetMedianRateEMA.selector, rateFeed.rateFeedID)
+          )
+        );
+      }
+
+      transactions.push(
+        ICeloGovernance.Transaction(
+          0,
+          breakerBox,
+          abi.encodeWithSelector(BreakerBox(0).toggleBreaker.selector, medianDeltaBreaker, rateFeed.rateFeedID, true)
+        )
+      );
+    }
+  }
+
+  /**
+   * @notice This function creates the transactions to configure the Median Delta Breaker.
+   */
+  function proposal_configureMedianDeltaBreaker(Config.RateFeed memory rateFeed) private {
+    // Set the cooldown time
+    transactions.push(
+      ICeloGovernance.Transaction(
+        0,
+        medianDeltaBreaker,
+        abi.encodeWithSelector(
+          MedianDeltaBreaker(0).setCooldownTime.selector,
+          Arrays.addresses(rateFeed.rateFeedID),
+          Arrays.uints(rateFeed.medianDeltaBreaker0.cooldown)
+        )
+      )
+    );
+    // Set the rate change threshold
+    transactions.push(
+      ICeloGovernance.Transaction(
+        0,
+        medianDeltaBreaker,
+        abi.encodeWithSelector(
+          MedianDeltaBreaker(0).setRateChangeThresholds.selector,
+          Arrays.addresses(rateFeed.rateFeedID),
+          Arrays.uints(rateFeed.medianDeltaBreaker0.threshold.unwrap())
+        )
+      )
+    );
+
+    // Set the smoothing factor
+    transactions.push(
+      ICeloGovernance.Transaction(
+        0,
+        medianDeltaBreaker,
+        abi.encodeWithSelector(
+          MedianDeltaBreaker(0).setSmoothingFactor.selector,
+          rateFeed.rateFeedID,
+          rateFeed.medianDeltaBreaker0.smoothingFactor
+        )
+      )
+    );
+  }
+}

--- a/script/upgrades/PoolRestructuring/PoolRestructuringChecks.sol
+++ b/script/upgrades/PoolRestructuring/PoolRestructuringChecks.sol
@@ -1,0 +1,453 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// solhint-disable var-name-mixedcase, func-name-mixedcase
+pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
+
+import { Test } from "forge-std/Test.sol";
+import { console2 } from "forge-std/console2.sol";
+import { Contracts } from "script/utils/Contracts.sol";
+import { Chain } from "script/utils/Chain.sol";
+import { Arrays } from "script/utils/Arrays.sol";
+import { GovernanceScript } from "script/utils/Script.sol";
+
+import { IBiPoolManager, FixidityLib } from "mento-core-2.5.0/interfaces/IBiPoolManager.sol";
+import { BreakerBox } from "mento-core-2.5.0/oracles/BreakerBox.sol";
+import { MedianDeltaBreaker } from "mento-core-2.5.0/oracles/breakers/MedianDeltaBreaker.sol";
+import { ValueDeltaBreaker } from "mento-core-2.5.0/oracles/breakers/ValueDeltaBreaker.sol";
+import { TradingLimits } from "mento-core-2.5.0/libraries/TradingLimits.sol";
+
+import { Config } from "script/utils/Config.sol";
+import { NewPoolsCfg } from "./NewPoolsCfg.sol";
+
+import { CfgHelper } from "script/upgrades/PoolRestructuring/CfgHelper.sol";
+import { PoolsCleanupCfg } from "script/upgrades/PoolRestructuring/PoolsCleanupCfg.sol";
+import { TradingLimitsCfg } from "script/upgrades/PoolRestructuring/TradingLimitsCfg.sol";
+import { ValueDeltaBreakerCfg } from "script/upgrades/PoolRestructuring/ValueDeltaBreakerCfg.sol";
+
+interface IBrokerWithCasts {
+  function tradingLimitsConfig(bytes32 id) external view returns (TradingLimits.Config memory);
+}
+
+contract PoolRestructuringChecks is GovernanceScript, Test {
+  using TradingLimits for TradingLimits.Config;
+  using Contracts for Contracts.Cache;
+
+  uint256 private constant PRE_EXISTING_POOLS = 24;
+
+  CfgHelper private cfgHelper;
+  PoolsCleanupCfg private poolsCleanupCfg;
+  TradingLimitsCfg private tradingLimitsCfg;
+  ValueDeltaBreakerCfg private valueDeltaBreakerCfg;
+
+  address private brokerProxy;
+  address private biPoolManagerProxy;
+  address private valueDeltaBreaker;
+  address private breakerBox;
+  address private medianDeltaBreaker;
+
+  address private constantSum;
+
+  mapping(address => bytes32) public referenceRateFeedIDToExchangeId;
+
+  function prepare() public {
+    contracts.loadSilent("MU01-00-Create-Proxies", "latest");
+    contracts.loadSilent("MU01-01-Create-Nonupgradeable-Contracts", "latest");
+    contracts.loadSilent("MU03-01-Create-Nonupgradeable-Contracts");
+    contracts.loadSilent("MU07-Deploy-ChainlinkRelayerFactory", "latest");
+    contracts.loadSilent("eXOF-00-Create-Proxies", "latest");
+
+    cfgHelper = new CfgHelper();
+    cfgHelper.load();
+
+    poolsCleanupCfg = new PoolsCleanupCfg(cfgHelper);
+    tradingLimitsCfg = new TradingLimitsCfg(cfgHelper);
+    valueDeltaBreakerCfg = new ValueDeltaBreakerCfg();
+
+    brokerProxy = contracts.deployed("BrokerProxy");
+    biPoolManagerProxy = contracts.deployed("BiPoolManagerProxy");
+    valueDeltaBreaker = contracts.deployed("ValueDeltaBreaker");
+    breakerBox = contracts.deployed("BreakerBox");
+    medianDeltaBreaker = contracts.deployed("MedianDeltaBreaker");
+
+    constantSum = contracts.deployed("ConstantSumPricingModule");
+
+    setReferenceRateFeedIDToExchangeId();
+  }
+
+  function run() public {
+    prepare();
+
+    console2.log("\n");
+
+    checkPoolsAreDeletedAndRecreatedWithNewSpread();
+    checkValueDeltaBreakersThresholds();
+    checkTradingLimits();
+
+    NewPoolsCfg.NewPools memory newPoolsCfg = NewPoolsCfg.get(contracts);
+    verifyExchanges(newPoolsCfg.pools);
+
+    verifyCircuitBreaker(newPoolsCfg.rateFeedsConfig);
+
+    console2.log("\n");
+    console2.log("✅ All checks passed\n");
+  }
+
+  function setReferenceRateFeedIDToExchangeId() public {
+    IBiPoolManager biPoolManager = IBiPoolManager(biPoolManagerProxy);
+    bytes32[] memory exchangeIds = biPoolManager.getExchangeIds();
+
+    for (uint256 i = 0; i < exchangeIds.length; i++) {
+      bytes32 exchangeId = exchangeIds[i];
+      IBiPoolManager.PoolExchange memory currentExchange = biPoolManager.getPoolExchange(exchangeId);
+
+      referenceRateFeedIDToExchangeId[currentExchange.config.referenceRateFeedID] = exchangeId;
+    }
+  }
+
+  function checkPoolsAreDeletedAndRecreatedWithNewSpread() internal {
+    console2.log("====🔍 Checking current pools state... ====");
+
+    IBiPoolManager biPoolManager = IBiPoolManager(biPoolManagerProxy);
+
+    bytes32[] memory exchangeIds = biPoolManager.getExchangeIds();
+    for (uint256 i = 0; i < exchangeIds.length; i++) {
+      bytes32 exchangeId = exchangeIds[i];
+      IBiPoolManager.PoolExchange memory exchange = biPoolManager.getPoolExchange(exchangeId);
+
+      if (poolsCleanupCfg.shouldBeDeleted(exchange)) {
+        // If this pool was supposed to be deleted but it's still there, it means it was part of the ones that
+        // had to be re-created with a new spread.
+        require(
+          poolsCleanupCfg.shouldRecreateWithNewSpread(exchange),
+          "❌ Failed to delete pool without a newly proposed spread"
+        );
+
+        (, FixidityLib.Fraction memory targetSpread) = poolsCleanupCfg.getCurrentAndTargetSpread(exchange);
+        require(FixidityLib.equals(exchange.config.spread, targetSpread), "❌ Re-created pool with wrong spread");
+
+        console2.log(
+          "✅ Re-created pool %s with new spread",
+          cfgHelper.getFeedName(exchange.config.referenceRateFeedID)
+        );
+      }
+    }
+
+    uint256 poolsDeletedButNotRecreated = poolsCleanupCfg.poolsToDelete().length -
+      poolsCleanupCfg.spreadOverrides().length;
+    console2.log("✅ Other non-USD pools (%d) were permanently deleted\n", poolsDeletedButNotRecreated);
+  }
+
+  function checkValueDeltaBreakersThresholds() internal {
+    console2.log("====🔍 Checking updated ValueDeltaBreaker thresholds... ====");
+
+    ValueDeltaBreakerCfg.Override[] memory overrides = valueDeltaBreakerCfg.valueDeltaBreakerOverrides();
+    for (uint256 i = 0; i < overrides.length; i++) {
+      uint256 currentThreshold = ValueDeltaBreaker(valueDeltaBreaker).rateChangeThreshold(overrides[i].rateFeedId);
+      require(currentThreshold == overrides[i].targetThreshold, "❌ ValueDeltaBreaker threshold not updated");
+
+      console2.log("✅ Threshold updated for %s feed", cfgHelper.getFeedName(overrides[i].rateFeedId));
+    }
+  }
+
+  function verifyExchanges(Config.Pool[] memory poolConfigs) internal {
+    console2.log("===🔍 Verifying exchanges ===");
+
+    NewPoolsCfg.NewPools memory newPoolsCfg = NewPoolsCfg.get(contracts);
+
+    bytes32[] memory exchanges = IBiPoolManager(biPoolManagerProxy).getExchangeIds();
+    // check configured pools against the config
+    require(
+      exchanges.length ==
+        PRE_EXISTING_POOLS -
+          poolsCleanupCfg.poolsToDelete().length + // pools that were deleted
+          poolsCleanupCfg.spreadOverrides().length + // pools that were re-created with a new spread
+          newPoolsCfg.pools.length, // 3 new cUSD pools
+      "Number of expected pools does not match the number of deployed pools."
+    );
+
+    for (uint256 i = 0; i < newPoolsCfg.pools.length; i++) {
+      bytes32 exchangeId = getExchangeId(
+        newPoolsCfg.pools[i].asset0,
+        newPoolsCfg.pools[i].asset1,
+        newPoolsCfg.pools[i].isConstantSum
+      );
+
+      verifyPoolExchange(exchangeId, newPoolsCfg.pools[i]);
+      verifyPoolConfig(exchangeId, newPoolsCfg.pools[i]);
+      verifyTradingLimits(exchangeId, newPoolsCfg.pools[i]);
+    }
+    console2.log("\n");
+  }
+
+  function verifyCircuitBreaker(Config.RateFeed[] memory rateFeedConfigs) internal view {
+    console2.log("===🔍 Checking circuit breaker ===");
+
+    for (uint256 i = 0; i < rateFeedConfigs.length; i++) {
+      verifyBreakersAreEnabled(rateFeedConfigs[i]);
+      verifyMedianDeltaBreaker(rateFeedConfigs[i]);
+    }
+  }
+
+  function verifyPoolExchange(bytes32 exchangeId, Config.Pool memory expectedPoolConfig) internal view {
+    IBiPoolManager.PoolExchange memory deployedPool = IBiPoolManager(biPoolManagerProxy).getPoolExchange(exchangeId);
+
+    // verify asset0 of the deployed pool against the config
+    if (deployedPool.asset0 != expectedPoolConfig.asset0) {
+      console2.log(
+        "The asset0 of deployed pool: %s does not match the expected asset0: %s.",
+        deployedPool.asset0,
+        expectedPoolConfig.asset0
+      );
+      revert("asset0 of pool does not match the expected asset0. See logs.");
+    }
+
+    // verify asset1 of the deployed pool against the config
+    if (deployedPool.asset1 != expectedPoolConfig.asset1) {
+      console2.log(
+        "The asset1 of deployed pool: %s does not match the expected asset1: %s.",
+        deployedPool.asset1,
+        expectedPoolConfig.asset1
+      );
+      revert("asset1 of pool does not match the expected asset1. See logs.");
+    }
+
+    // Ensure the pricing module is the constant product
+    if (address(deployedPool.pricingModule) != constantSum) {
+      console2.log(
+        "The pricing module of deployed pool: %s does not match the expected pricing module: %s.",
+        address(deployedPool.pricingModule),
+        constantSum
+      );
+      revert("pricing module of pool does not match the expected pricing module. See logs.");
+    }
+
+    console2.log(
+      "🟢 PoolExchange for %s has correct assets and pricing 🤘🏼",
+      cfgHelper.getFeedName(deployedPool.config.referenceRateFeedID)
+    );
+  }
+
+  function verifyPoolConfig(bytes32 exchangeId, Config.Pool memory expectedPoolConfig) internal view {
+    IBiPoolManager.PoolExchange memory deployedPool = IBiPoolManager(biPoolManagerProxy).getPoolExchange(exchangeId);
+
+    // if (deployedPool.config.spread.unwrap() != expectedPoolConfig.spread.unwrap()) {
+    //   console2.log(
+    //     "The spread of deployed pool: %s does not match the expected spread: %s.",
+    //     deployedPool.config.spread.unwrap(),
+    //     expectedPoolConfig.spread.unwrap()
+    //   );
+    //   revert("spread of pool does not match the expected spread. See logs.");
+    // }
+
+    // console2.log("Expected spread: %s", expectedPoolConfig.spread.unwrap());
+    // console2.log("Deployed spread: %s", deployedPool.config.spread.unwrap());
+    // if (FixidityLib.equals(deployedPool.config.spread, expectedPoolConfig.spread)) {
+    //   console2.log("✅ Spread is correct");
+    // } else {
+    //   console2.log("❌ Spread is incorrect");
+    // }
+
+    if (deployedPool.config.referenceRateFeedID != expectedPoolConfig.referenceRateFeedID) {
+      console2.log(
+        "The referenceRateFeedID of deployed pool: %s does not match the expected referenceRateFeedID: %s.",
+        deployedPool.config.referenceRateFeedID,
+        expectedPoolConfig.referenceRateFeedID
+      );
+      revert("referenceRateFeedID of pool does not match the expected referenceRateFeedID. See logs.");
+    }
+
+    if (deployedPool.config.minimumReports != expectedPoolConfig.minimumReports) {
+      console2.log(
+        "The minimumReports of deployed pool: %s does not match the expected minimumReports: %s.",
+        deployedPool.config.minimumReports,
+        expectedPoolConfig.minimumReports
+      );
+      revert("minimumReports of pool does not match the expected minimumReports. See logs.");
+    }
+
+    if (deployedPool.config.referenceRateResetFrequency != expectedPoolConfig.referenceRateResetFrequency) {
+      console2.log(
+        "The referenceRateResetFrequency of deployed pool: %s does not match the expected: %s.",
+        deployedPool.config.referenceRateResetFrequency,
+        expectedPoolConfig.referenceRateResetFrequency
+      );
+      revert("referenceRateResetFrequency of pool does not match the expected referenceRateResetFrequency. See logs.");
+    }
+
+    if (deployedPool.config.stablePoolResetSize != expectedPoolConfig.stablePoolResetSize) {
+      console2.log(
+        "The stablePoolResetSize of deployed pool: %s does not match the expected stablePoolResetSize: %s.",
+        deployedPool.config.stablePoolResetSize,
+        expectedPoolConfig.stablePoolResetSize
+      );
+      revert("stablePoolResetSize of pool does not match the expected stablePoolResetSize. See logs.");
+    }
+
+    console2.log("🟢 %s config is correct🤘🏼", cfgHelper.getFeedName(deployedPool.config.referenceRateFeedID));
+  }
+
+  function verifyTradingLimits(bytes32 exchangeId, Config.Pool memory expectedPoolConfig) internal view {
+    IBrokerWithCasts _broker = IBrokerWithCasts(address(brokerProxy));
+
+    IBiPoolManager.PoolExchange memory pool = IBiPoolManager(biPoolManagerProxy).getPoolExchange(exchangeId);
+
+    bytes32 asset0LimitId = exchangeId ^ bytes32(uint256(uint160(pool.asset0)));
+    TradingLimits.Config memory asset0ActualLimit = _broker.tradingLimitsConfig(asset0LimitId);
+
+    bytes32 asset1LimitId = exchangeId ^ bytes32(uint256(uint160(pool.asset1)));
+    TradingLimits.Config memory asset1ActualLimit = _broker.tradingLimitsConfig(asset1LimitId);
+
+    checkTradingLimt(expectedPoolConfig.asset0limits, asset0ActualLimit);
+    checkTradingLimt(expectedPoolConfig.asset1limits, asset1ActualLimit);
+
+    console2.log("🟢 Trading limits set for %s 🔒\n", cfgHelper.getFeedName(pool.config.referenceRateFeedID));
+  }
+
+  function verifyBreakersAreEnabled(Config.RateFeed memory expectedRateFeedConfig) internal view {
+    // verify that MedianDeltaBreaker is enabled
+    if (expectedRateFeedConfig.medianDeltaBreaker0.enabled) {
+      bool medianDeltaEnabled = BreakerBox(breakerBox).isBreakerEnabled(
+        medianDeltaBreaker,
+        expectedRateFeedConfig.rateFeedID
+      );
+      if (!medianDeltaEnabled) {
+        console2.log("MedianDeltaBreaker not enabled for rate feed %s", expectedRateFeedConfig.rateFeedID);
+        revert("MedianDeltaBreaker not enabled for all rate feeds");
+      }
+    }
+    console2.log(
+      "🟢 Breakers enabled for the rate feed %s 🗳️",
+      cfgHelper.getFeedName(expectedRateFeedConfig.rateFeedID)
+    );
+  }
+
+  function verifyMedianDeltaBreaker(Config.RateFeed memory expectedRateFeedConfig) internal view {
+    // verify that cooldown period, rate change threshold and smoothing factor were set correctly
+    if (expectedRateFeedConfig.medianDeltaBreaker0.enabled) {
+      // Get the actual values from the deployed median delta breaker contract
+      uint256 cooldown = MedianDeltaBreaker(medianDeltaBreaker).getCooldown(expectedRateFeedConfig.rateFeedID);
+      uint256 rateChangeThreshold = MedianDeltaBreaker(medianDeltaBreaker).rateChangeThreshold(
+        expectedRateFeedConfig.rateFeedID
+      );
+      uint256 smoothingFactor = MedianDeltaBreaker(medianDeltaBreaker).getSmoothingFactor(
+        expectedRateFeedConfig.rateFeedID
+      );
+
+      // verify cooldown period
+      verifyCooldownTime(
+        cooldown,
+        expectedRateFeedConfig.medianDeltaBreaker0.cooldown,
+        expectedRateFeedConfig.rateFeedID,
+        false
+      );
+
+      // verify rate change threshold
+      verifyRateChangeTheshold(
+        rateChangeThreshold,
+        expectedRateFeedConfig.medianDeltaBreaker0.threshold.unwrap(),
+        expectedRateFeedConfig.rateFeedID,
+        false
+      );
+
+      // verify smoothing factor
+      if (smoothingFactor != expectedRateFeedConfig.medianDeltaBreaker0.smoothingFactor) {
+        console2.log("expected: %s", expectedRateFeedConfig.medianDeltaBreaker0.smoothingFactor);
+        console2.log("got:      %s", smoothingFactor);
+        console2.log(
+          "MedianDeltaBreaker smoothing factor not set correctly for the rate feed: %s",
+          expectedRateFeedConfig.rateFeedID
+        );
+        revert("MedianDeltaBreaker smoothing factor not set correctly for all rate feeds");
+      }
+    }
+    console2.log("🟢 MedianDeltaBreaker cooldown, rate change threshold and smoothing factor set correctly 🔒\r\n");
+  }
+
+  function verifyRateChangeTheshold(
+    uint256 currentThreshold,
+    uint256 expectedThreshold,
+    address rateFeedID,
+    bool isValueDeltaBreaker
+  ) internal view {
+    if (currentThreshold != expectedThreshold) {
+      if (isValueDeltaBreaker) {
+        console2.log("ValueDeltaBreaker rate change threshold not set correctly for rate feed with id %s", rateFeedID);
+        revert("ValueDeltaBreaker rate change threshold not set correctly for rate feed");
+      }
+      console2.log("MedianDeltaBreaker rate change threshold not set correctly for rate feed %s", rateFeedID);
+      revert("MedianDeltaBreaker rate change threshold not set correctly for all rate feeds");
+    }
+  }
+
+  function verifyCooldownTime(
+    uint256 currentCoolDown,
+    uint256 expectedCoolDown,
+    address rateFeedID,
+    bool isValueDeltaBreaker
+  ) internal view {
+    if (currentCoolDown != expectedCoolDown) {
+      console2.log("currentCoolDown: %s", currentCoolDown);
+      console2.log("expectedCoolDown: %s", expectedCoolDown);
+      if (isValueDeltaBreaker) {
+        console2.log("ValueDeltaBreaker cooldown not set correctly for rate feed with id %s", rateFeedID);
+        revert("ValueDeltaBreaker cooldown not set correctly for rate feed");
+      }
+      console2.log("MedianDeltaBreaker cooldown not set correctly for rate feed %s", rateFeedID);
+      revert("MedianDeltaBreaker cooldown not set correctly for all rate feeds");
+    }
+  }
+
+  function checkTradingLimits() internal {
+    console2.log("====🔍 Checking updated trading limits... ====");
+
+    IBrokerWithCasts _broker = IBrokerWithCasts(brokerProxy);
+    TradingLimitsCfg.Override[] memory overrides = tradingLimitsCfg.tradingLimitsOverrides();
+
+    for (uint256 i = 0; i < overrides.length; i++) {
+      bytes32 exchangeId = referenceRateFeedIDToExchangeId[overrides[i].referenceRateFeedID];
+
+      bytes32 asset0LimitId = exchangeId ^ bytes32(uint256(uint160(overrides[i].asset0)));
+      TradingLimits.Config memory asset0ActualLimit = _broker.tradingLimitsConfig(asset0LimitId);
+
+      bytes32 asset1LimitId = exchangeId ^ bytes32(uint256(uint160(overrides[i].asset1)));
+      TradingLimits.Config memory asset1ActualLimit = _broker.tradingLimitsConfig(asset1LimitId);
+
+      checkTradingLimt(overrides[i].asset0Config, asset0ActualLimit);
+      checkTradingLimt(overrides[i].asset1Config, asset1ActualLimit);
+
+      console2.log("✅ Trading limits updated for %s feed", cfgHelper.getFeedName(overrides[i].referenceRateFeedID));
+    }
+  }
+
+  function checkTradingLimt(
+    Config.TradingLimit memory expectedTradingLimit,
+    TradingLimits.Config memory actualTradingLimit
+  ) internal view {
+    if (expectedTradingLimit.limit0 != actualTradingLimit.limit0) {
+      console2.log("limit0 was not set as expected ❌");
+      revert("Not all trading limits were configured correctly.");
+    }
+    if (expectedTradingLimit.limit1 != actualTradingLimit.limit1) {
+      console2.log("limit1 was not set as expected ❌");
+      revert("Not all trading limits were configured correctly.");
+    }
+    if (expectedTradingLimit.limitGlobal != actualTradingLimit.limitGlobal) {
+      console2.log("limitGlobal was not set as expected ❌");
+      revert("Not all trading limits were configured correctly.");
+    }
+    if (expectedTradingLimit.timeStep0 != actualTradingLimit.timestep0) {
+      console2.log("timestep0 was not set as expected ❌");
+      revert("Not all trading limits were configured correctly.");
+    }
+    if (expectedTradingLimit.timeStep1 != actualTradingLimit.timestep1) {
+      console2.log("timestep1 was not set as expected ❌");
+      revert("Not all trading limits were configured correctly.");
+    }
+
+    uint8 tradingLimitFlags = Config.tradingLimitConfigToFlag(expectedTradingLimit);
+    if (tradingLimitFlags != actualTradingLimit.flags) {
+      console2.log("flags were not set as expected ❌");
+      revert("Not all trading limits were configured correctly.");
+    }
+  }
+}

--- a/script/upgrades/PoolRestructuring/PoolRestructuringChecks.sol
+++ b/script/upgrades/PoolRestructuring/PoolRestructuringChecks.sol
@@ -170,12 +170,17 @@ contract PoolRestructuringChecks is GovernanceScript, Test {
       verifyPoolExchange(exchangeId, newPoolsCfg.pools[i]);
       verifyPoolConfig(exchangeId, newPoolsCfg.pools[i]);
       verifyTradingLimits(exchangeId, newPoolsCfg.pools[i]);
+
+      console2.log(
+        "🟢 %s pool has the expected params and trading limits",
+        cfgHelper.getFeedName(newPoolsCfg.pools[i].referenceRateFeedID)
+      );
     }
     console2.log("\n");
   }
 
   function verifyCircuitBreaker(Config.RateFeed[] memory rateFeedConfigs) internal view {
-    console2.log("===🔍 Checking circuit breaker ===");
+    console2.log("===🔍 Verifying circuit breaker on new pools ===");
 
     for (uint256 i = 0; i < rateFeedConfigs.length; i++) {
       verifyBreakersAreEnabled(rateFeedConfigs[i]);
@@ -189,11 +194,6 @@ contract PoolRestructuringChecks is GovernanceScript, Test {
     require(deployedPool.asset0 == expectedPoolConfig.asset0, "❌ asset0 mismatch");
     require(deployedPool.asset1 == expectedPoolConfig.asset1, "❌ asset1 mismatch");
     require(address(deployedPool.pricingModule) == constantSum, "❌ pricing module mismatch");
-
-    console2.log(
-      "🟢 %s pool has correct assets and pricing",
-      cfgHelper.getFeedName(deployedPool.config.referenceRateFeedID)
-    );
   }
 
   function verifyPoolConfig(bytes32 exchangeId, Config.Pool memory expectedPoolConfig) internal view {
@@ -212,9 +212,6 @@ contract PoolRestructuringChecks is GovernanceScript, Test {
       deployedPool.config.stablePoolResetSize == expectedPoolConfig.stablePoolResetSize,
       "❌ stablePoolResetSize mismatch"
     );
-
-    string memory feedName = cfgHelper.getFeedName(deployedPool.config.referenceRateFeedID);
-    console2.log("🟢 %s pool config is correct", feedName);
   }
 
   function verifyTradingLimits(bytes32 exchangeId, Config.Pool memory expectedPoolConfig) internal view {
@@ -230,8 +227,6 @@ contract PoolRestructuringChecks is GovernanceScript, Test {
 
     compareTradingLimits(expectedPoolConfig.asset0limits, asset0ActualLimit);
     compareTradingLimits(expectedPoolConfig.asset1limits, asset1ActualLimit);
-
-    console2.log("🟢 Trading limits set for %s", cfgHelper.getFeedName(pool.config.referenceRateFeedID));
   }
 
   function verifyBreakersAreEnabled(Config.RateFeed memory expectedRateFeedConfig) internal view {

--- a/script/upgrades/PoolRestructuring/PoolsCleanupCfg.sol
+++ b/script/upgrades/PoolRestructuring/PoolsCleanupCfg.sol
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// solhint-disable func-name-mixedcase, contract-name-camelcase, function-max-lines, var-name-mixedcase
+pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
+
+import { GovernanceScript } from "script/utils/Script.sol";
+import { IBiPoolManager, FixidityLib } from "mento-core-2.5.0/interfaces/IBiPoolManager.sol";
+
+import { Config } from "script/utils/Config.sol";
+import { CfgHelper } from "script/upgrades/PoolRestructuring/CfgHelper.sol";
+
+contract PoolsCleanupCfg is GovernanceScript {
+  CfgHelper private cfgHelper;
+
+  struct PoolToDelete {
+    address asset0;
+    address asset1;
+    address rateFeedId;
+  }
+
+  struct SpreadOverride {
+    address asset0;
+    address asset1;
+    address rateFeedId;
+    FixidityLib.Fraction currentSpread;
+    FixidityLib.Fraction targetSpread;
+  }
+
+  constructor(CfgHelper _cfgHelper) public {
+    cfgHelper = _cfgHelper;
+  }
+
+  function poolsToDelete() public view returns (PoolToDelete[] memory) {
+    PoolToDelete[] memory pools = new PoolToDelete[](13);
+
+    // non-USD pools that won't be re-created and will be gone for good
+    pools[0] = PoolToDelete({
+      asset0: cfgHelper.cEURProxy(),
+      asset1: cfgHelper.CELOProxy(),
+      rateFeedId: cfgHelper.cEURProxy()
+    });
+    pools[1] = PoolToDelete({
+      asset0: cfgHelper.cBRLProxy(),
+      asset1: cfgHelper.CELOProxy(),
+      rateFeedId: cfgHelper.cBRLProxy()
+    });
+    pools[2] = PoolToDelete({
+      asset0: cfgHelper.cBRLProxy(),
+      asset1: cfgHelper.nativeUSDCProxy(),
+      rateFeedId: toRateFeedId("USDCBRL")
+    });
+    pools[3] = PoolToDelete({
+      asset0: cfgHelper.cEURProxy(),
+      asset1: cfgHelper.axlUSDCProxy(),
+      rateFeedId: toRateFeedId("USDCEUR")
+    });
+    pools[4] = PoolToDelete({
+      asset0: cfgHelper.cBRLProxy(),
+      asset1: cfgHelper.axlUSDCProxy(),
+      rateFeedId: toRateFeedId("USDCBRL")
+    });
+    pools[5] = PoolToDelete({
+      asset0: cfgHelper.eXOFProxy(),
+      asset1: cfgHelper.CELOProxy(),
+      rateFeedId: cfgHelper.eXOFProxy()
+    });
+    pools[6] = PoolToDelete({
+      asset0: cfgHelper.eXOFProxy(),
+      asset1: cfgHelper.axlEUROCProxy(),
+      rateFeedId: toRateFeedId("EUROCXOF")
+    });
+    pools[7] = PoolToDelete({
+      asset0: cfgHelper.cEURProxy(),
+      asset1: cfgHelper.nativeUSDCProxy(),
+      rateFeedId: toRateFeedId("USDCEUR")
+    });
+
+    // pools that will be re-created with a new spread, but need to be deleted first
+    pools[8] = PoolToDelete({
+      asset0: cfgHelper.cUSDProxy(),
+      asset1: cfgHelper.nativeUSDCProxy(),
+      rateFeedId: toRateFeedId("USDCUSD")
+    });
+    pools[9] = PoolToDelete({
+      asset0: cfgHelper.cUSDProxy(),
+      asset1: cfgHelper.nativeUSDTProxy(),
+      rateFeedId: toRateFeedId("USDTUSD")
+    });
+    pools[10] = PoolToDelete({
+      asset0: cfgHelper.cUSDProxy(),
+      asset1: cfgHelper.axlUSDCProxy(),
+      rateFeedId: toRateFeedId("USDCUSD")
+    });
+    pools[11] = PoolToDelete({
+      asset0: cfgHelper.cUSDProxy(),
+      asset1: cfgHelper.cCADProxy(),
+      rateFeedId: toRateFeedId("relayed:CADUSD")
+    });
+    pools[12] = PoolToDelete({
+      asset0: cfgHelper.cUSDProxy(),
+      asset1: cfgHelper.cAUDProxy(),
+      rateFeedId: toRateFeedId("relayed:AUDUSD")
+    });
+
+    return pools;
+  }
+
+  function spreadOverrides() public view returns (SpreadOverride[] memory) {
+    SpreadOverride[] memory overrides = new SpreadOverride[](5);
+    // cUSD/nativeUSDC
+    overrides[0] = SpreadOverride({
+      asset0: cfgHelper.cUSDProxy(),
+      asset1: cfgHelper.nativeUSDCProxy(),
+      rateFeedId: toRateFeedId("USDCUSD"),
+      currentSpread: FixidityLib.newFixedFraction(5, 10000), // 0.05%
+      targetSpread: FixidityLib.newFixed(0) // 0%
+    });
+    // cUSD/USDT
+    overrides[1] = SpreadOverride({
+      asset0: cfgHelper.cUSDProxy(),
+      asset1: cfgHelper.nativeUSDTProxy(),
+      rateFeedId: toRateFeedId("USDTUSD"),
+      currentSpread: FixidityLib.newFixedFraction(5, 10000), // 0.05%
+      targetSpread: FixidityLib.newFixed(0) // 0%
+    });
+    // cUSD/axlUSDC
+    overrides[2] = SpreadOverride({
+      asset0: cfgHelper.cUSDProxy(),
+      asset1: cfgHelper.axlUSDCProxy(),
+      rateFeedId: toRateFeedId("USDCUSD"),
+      currentSpread: FixidityLib.newFixedFraction(25, 10000), // 0.25%
+      targetSpread: FixidityLib.newFixed(0) // 0%
+    });
+    // cUSD/cCAD
+    overrides[3] = SpreadOverride({
+      asset0: cfgHelper.cUSDProxy(),
+      asset1: cfgHelper.cCADProxy(),
+      rateFeedId: toRateFeedId("relayed:CADUSD"),
+      currentSpread: FixidityLib.newFixedFraction(3, 1000), // 0.3%
+      targetSpread: FixidityLib.newFixedFraction(15, 10000) // 0.15%
+    });
+    // cUSD/cAUD
+    overrides[4] = SpreadOverride({
+      asset0: cfgHelper.cUSDProxy(),
+      asset1: cfgHelper.cAUDProxy(),
+      rateFeedId: toRateFeedId("relayed:AUDUSD"),
+      currentSpread: FixidityLib.newFixedFraction(3, 1000), // 0.3%
+      targetSpread: FixidityLib.newFixedFraction(15, 10000) // 0.15%
+    });
+
+    return overrides;
+  }
+
+  function shouldBeDeleted(IBiPoolManager.PoolExchange memory poolCfg) public view returns (bool) {
+    PoolToDelete[] memory pools = poolsToDelete();
+    for (uint256 i = 0; i < pools.length; i++) {
+      if (pools[i].asset0 == poolCfg.asset0 && pools[i].asset1 == poolCfg.asset1) {
+        require(pools[i].rateFeedId == poolCfg.config.referenceRateFeedID, "Rate feed ID mismatch in pool to delete");
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  function shouldRecreateWithNewSpread(IBiPoolManager.PoolExchange memory poolCfg) public view returns (bool) {
+    SpreadOverride[] memory overrides = spreadOverrides();
+    for (uint256 i = 0; i < overrides.length; i++) {
+      if (overrides[i].asset0 == poolCfg.asset0 && overrides[i].asset1 == poolCfg.asset1) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  function getPoolCfgWithNewSpread(
+    IBiPoolManager.PoolExchange memory currentExchange
+  ) public view returns (IBiPoolManager.PoolExchange memory) {
+    IBiPoolManager.PoolExchange memory newExchange = currentExchange;
+    (FixidityLib.Fraction memory currentSpread, FixidityLib.Fraction memory targetSpread) = getCurrentAndTargetSpread(
+      currentExchange
+    );
+    require(
+      FixidityLib.equals(newExchange.config.spread, currentSpread),
+      "❌ Current spread mismatch on spread override"
+    );
+
+    newExchange.config.spread = targetSpread;
+    // Automatically adjusted by the biPoolManager upon creation
+    newExchange.bucket0 = 0;
+    newExchange.bucket1 = 0;
+    newExchange.lastBucketUpdate = 0;
+
+    return newExchange;
+  }
+
+  function getCurrentAndTargetSpread(
+    IBiPoolManager.PoolExchange memory poolCfg
+  ) public view returns (FixidityLib.Fraction memory, FixidityLib.Fraction memory) {
+    SpreadOverride[] memory overrides = spreadOverrides();
+    for (uint256 i = 0; i < overrides.length; i++) {
+      if (overrides[i].asset0 == poolCfg.asset0 && overrides[i].asset1 == poolCfg.asset1) {
+        return (overrides[i].currentSpread, overrides[i].targetSpread);
+      }
+    }
+
+    require(false, "getCurrentAndTargetSpread() called on a pool with no spread override");
+  }
+}

--- a/script/upgrades/PoolRestructuring/TradingLimitsCfg.sol
+++ b/script/upgrades/PoolRestructuring/TradingLimitsCfg.sol
@@ -1,0 +1,355 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// solhint-disable func-name-mixedcase, contract-name-camelcase, function-max-lines, var-name-mixedcase
+pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
+
+import { GovernanceScript } from "script/utils/Script.sol";
+
+import { Config } from "script/utils/Config.sol";
+import { CfgHelper } from "script/upgrades/PoolRestructuring/CfgHelper.sol";
+
+contract TradingLimitsCfg is GovernanceScript {
+  CfgHelper private cfgHelper;
+
+  struct Override {
+    address asset0;
+    address asset1;
+    address referenceRateFeedID;
+    Config.TradingLimit asset0Config;
+    Config.TradingLimit asset1Config;
+  }
+
+  constructor(CfgHelper _cfgHelper) public {
+    cfgHelper = _cfgHelper;
+  }
+
+  function tradingLimitsOverrides() public view returns (Override[] memory) {
+    Override[] memory overrides = new Override[](13);
+
+    // cEUR/axlEUROC
+    overrides[0] = Override({
+      asset0: cfgHelper.cEURProxy(),
+      asset1: cfgHelper.axlEUROCProxy(),
+      referenceRateFeedID: toRateFeedId("EUROCEUR"),
+      asset0Config: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 100_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 500_000,
+        enabledGlobal: false,
+        limitGlobal: 0
+      }),
+      asset1Config: Config.emptyTradingLimitConfig()
+    });
+
+    // cUSD/nativeUSDT
+    overrides[1] = Override({
+      asset0: cfgHelper.cUSDProxy(),
+      asset1: cfgHelper.nativeUSDTProxy(),
+      referenceRateFeedID: toRateFeedId("USDTUSD"),
+      asset0Config: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 2_500_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 5_000_000,
+        enabledGlobal: false,
+        limitGlobal: 0
+      }),
+      asset1Config: Config.emptyTradingLimitConfig()
+    });
+
+    // cUSD/PUSO
+    overrides[2] = Override({
+      asset0: cfgHelper.cUSDProxy(),
+      asset1: cfgHelper.PUSOProxy(),
+      referenceRateFeedID: toRateFeedId("relayed:PHPUSD"),
+      asset0Config: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 100_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 500_000,
+        enabledGlobal: true,
+        limitGlobal: 2_500_000
+      }),
+      asset1Config: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 5_700_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 28_500_000,
+        enabledGlobal: true,
+        limitGlobal: 142_500_000
+      })
+    });
+
+    // cUSD/cJPY
+    overrides[3] = Override({
+      asset0: cfgHelper.cUSDProxy(),
+      asset1: cfgHelper.cJPYProxy(),
+      referenceRateFeedID: toRateFeedId("relayed:JPYUSD"),
+      asset0Config: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 100_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 500_000,
+        enabledGlobal: true,
+        limitGlobal: 2_500_000
+      }),
+      asset1Config: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 14_200_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 71_000_000,
+        enabledGlobal: true,
+        limitGlobal: 355_000_000
+      })
+    });
+
+    // cUSD/cCOP
+    overrides[4] = Override({
+      asset0: cfgHelper.cUSDProxy(),
+      asset1: cfgHelper.cCOPProxy(),
+      referenceRateFeedID: toRateFeedId("relayed:COPUSD"),
+      asset0Config: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 50_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 250_000,
+        enabledGlobal: true,
+        limitGlobal: 1_250_000
+      }),
+      asset1Config: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 210_550_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 1_052_750_000,
+        enabledGlobal: true,
+        limitGlobal: 5_263_750_000
+      })
+    });
+
+    // cUSD/cGHS
+    overrides[5] = Override({
+      asset0: cfgHelper.cUSDProxy(),
+      asset1: cfgHelper.cGHSProxy(),
+      referenceRateFeedID: toRateFeedId("relayed:GHSUSD"),
+      asset0Config: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 50_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 250_000,
+        enabledGlobal: true,
+        limitGlobal: 1_250_000
+      }),
+      asset1Config: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 500_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 2_500_000,
+        enabledGlobal: true,
+        limitGlobal: 12_500_000
+      })
+    });
+
+    // cUSD/cGBP
+    overrides[6] = Override({
+      asset0: cfgHelper.cUSDProxy(),
+      asset1: cfgHelper.cGBPProxy(),
+      referenceRateFeedID: toRateFeedId("relayed:GBPUSD"),
+      asset0Config: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 100_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 500_000,
+        enabledGlobal: true,
+        limitGlobal: 2_500_000
+      }),
+      asset1Config: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 77_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 385_000,
+        enabledGlobal: true,
+        limitGlobal: 1_925_000
+      })
+    });
+
+    // cUSD/cZAR
+    overrides[7] = Override({
+      asset0: cfgHelper.cUSDProxy(),
+      asset1: cfgHelper.cZARProxy(),
+      referenceRateFeedID: toRateFeedId("relayed:ZARUSD"),
+      asset0Config: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 100_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 500_000,
+        enabledGlobal: true,
+        limitGlobal: 2_500_000
+      }),
+      asset1Config: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 1_800_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 9_000_000,
+        enabledGlobal: true,
+        limitGlobal: 45_000_000
+      })
+    });
+
+    // cUSD/cCAD
+    overrides[8] = Override({
+      asset0: cfgHelper.cUSDProxy(),
+      asset1: cfgHelper.cCADProxy(),
+      referenceRateFeedID: toRateFeedId("relayed:CADUSD"),
+      asset0Config: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 100_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 500_000,
+        enabledGlobal: true,
+        limitGlobal: 2_500_000
+      }),
+      asset1Config: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 140_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 700_000,
+        enabledGlobal: true,
+        limitGlobal: 3_500_000
+      })
+    });
+
+    // cUSD/cAUD
+    overrides[9] = Override({
+      asset0: cfgHelper.cUSDProxy(),
+      asset1: cfgHelper.cAUDProxy(),
+      referenceRateFeedID: toRateFeedId("relayed:AUDUSD"),
+      asset0Config: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 100_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 500_000,
+        enabledGlobal: true,
+        limitGlobal: 2_500_000
+      }),
+      asset1Config: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 160_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 800_000,
+        enabledGlobal: true,
+        limitGlobal: 4_000_000
+      })
+    });
+
+    // cUSD/cCHF
+    overrides[10] = Override({
+      asset0: cfgHelper.cUSDProxy(),
+      asset1: cfgHelper.cCHFProxy(),
+      referenceRateFeedID: toRateFeedId("relayed:CHFUSD"),
+      asset0Config: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 100_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 500_000,
+        enabledGlobal: true,
+        limitGlobal: 2_500_000
+      }),
+      asset1Config: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 83_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 415_000,
+        enabledGlobal: true,
+        limitGlobal: 2_075_000
+      })
+    });
+
+    // cUSD/cNGN
+    overrides[11] = Override({
+      asset0: cfgHelper.cUSDProxy(),
+      asset1: cfgHelper.cNGNProxy(),
+      referenceRateFeedID: toRateFeedId("relayed:NGNUSD"),
+      asset0Config: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 100_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 500_000,
+        enabledGlobal: true,
+        limitGlobal: 2_500_000
+      }),
+      asset1Config: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 161_200_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 806_000_000,
+        enabledGlobal: true,
+        limitGlobal: 4_030_000_000
+      })
+    });
+
+    // cUSD/CELO
+    overrides[12] = Override({
+      asset0: cfgHelper.cUSDProxy(),
+      asset1: cfgHelper.CELOProxy(),
+      referenceRateFeedID: cfgHelper.cUSDProxy(),
+      asset0Config: Config.TradingLimit({
+        enabled0: true,
+        timeStep0: 5 minutes,
+        limit0: 100_000,
+        enabled1: true,
+        timeStep1: 1 days,
+        limit1: 500_000,
+        enabledGlobal: false,
+        limitGlobal: 0
+      }),
+      asset1Config: Config.emptyTradingLimitConfig()
+    });
+
+    return overrides;
+  }
+}

--- a/script/upgrades/PoolRestructuring/ValueDeltaBreakerCfg.sol
+++ b/script/upgrades/PoolRestructuring/ValueDeltaBreakerCfg.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// solhint-disable func-name-mixedcase, contract-name-camelcase, function-max-lines, var-name-mixedcase
+pragma solidity ^0.5.13;
+pragma experimental ABIEncoderV2;
+
+import { GovernanceScript } from "script/utils/Script.sol";
+
+contract ValueDeltaBreakerCfg is GovernanceScript {
+  struct Override {
+    address rateFeedId;
+    uint256 currentThreshold;
+    uint256 targetThreshold;
+  }
+
+  function valueDeltaBreakerOverrides() public view returns (Override[] memory) {
+    Override[] memory overrides = new Override[](2);
+    // cUSD/USDC and cUSD/axlUSDC (both use the same rate feed id)
+    overrides[0] = Override({
+      rateFeedId: toRateFeedId("USDCUSD"),
+      currentThreshold: 5000000000000000000000, // 0.005 or 5e21
+      targetThreshold: 1000000000000000000000 // 0.001 or 1e21
+    });
+    // cUSD/USDT
+    overrides[1] = Override({
+      rateFeedId: toRateFeedId("USDTUSD"),
+      currentThreshold: 5000000000000000000000, // 0.005 or 5e21
+      targetThreshold: 1000000000000000000000 // 0.001 or 1e21
+    });
+    return overrides;
+  }
+}


### PR DESCRIPTION
### Description

This is the deployment script for [CGP187](https://forum.celo.org/t/streamlining-mento-reserve-pairs/11415). The transactions in this proposal can be divided into two sections:

- Deletion and re-configuration operations on some of our existing pools
  - Delete non-cUSD pools from the BipoolManager, except for cEUR/EUROC
  - Reconfigure the spread, ValueDeltaBreaker and Trading Limits configuration of some of the pools

- Creation of 3 new pools (cUSD/cEUR, cUSD/cREAL, cUSD/eXOF)
  - Typical pool creation process of adding the new exchange, configuring its trading limits and circuit breaker 

All of the new configuration values used throughout this PR (i.e. which pools are being deleted, new spreads/trading limits, etc) were taken from this [this spreadsheet](https://docs.google.com/spreadsheets/d/17wVmnrhSAxZcYWez9PJZTN39dPOoIe1kkGWJA8_LPsM/edit?gid=0#gid=0). The actual values are splited across a few different files in this PR:

- `PoolsCleanupCfg.sol`: Pools to be deleted and new spread parameters
- `ValueDeltaBreakerCfg.sol`: New ValueDeltaBreaker threshold parameters
- `TradingLimitsCfg.sol`: New trading limits
- `NewPoolsCfg.sol`: Configuration values for the 3 new additional pools

While reviewing this PR it's very important to cross check every value used in the above files against what was proposed in the spreadsheet.

### Tested

Simulations are green on both Alfajores and Mainnet. I'll cross check the final on-chain values using the visualization scripts in the SDK once this PR is merged and the proposal is executed on Alfajores
