### PR TITLE
feat: add sortedOracles transfer to MU08

### DIFF
--- a/script/upgrades/MU08/MU08.md
+++ b/script/upgrades/MU08/MU08.md
@@ -34,6 +34,7 @@ MentoV2 contracts:
 - BiPoolManager + BiPoolManagerProxy
 - Broker + BrokerProxy
 - Reserve + ReserveProxy
+- SortedOraclesProxy
 - BreakerBox
 - MedianDeltaBreaker
 - ValueDeltaBreaker

--- a/script/upgrades/MU08/MU08.sol
+++ b/script/upgrades/MU08/MU08.sol
@@ -66,6 +66,7 @@ contract MU08 is IMentoUpgrade, GovernanceScript {
   address private brokerProxy;
   address private biPoolManagerProxy;
   address private reserveProxy;
+  address private sortedOraclesProxy;
   address private breakerBox;
   address private medianDeltaBreaker;
   address private valueDeltaBreaker;
@@ -141,6 +142,7 @@ contract MU08 is IMentoUpgrade, GovernanceScript {
     brokerProxy = address(uint160(contracts.deployed("BrokerProxy")));
     biPoolManagerProxy = address(uint160(contracts.deployed("BiPoolManagerProxy")));
     reserveProxy = address(uint160(contracts.celoRegistry("Reserve")));
+    sortedOraclesProxy = address(uint160(contracts.celoRegistry("SortedOracles")));
     breakerBox = address(uint160(contracts.deployed("BreakerBox")));
     medianDeltaBreaker = address(uint160(contracts.deployed("MedianDeltaBreaker")));
     valueDeltaBreaker = address(uint160(contracts.deployed("ValueDeltaBreaker")));
@@ -394,7 +396,12 @@ contract MU08 is IMentoUpgrade, GovernanceScript {
   }
 
   function proposal_transferMentoV2Ownership() public {
-    address[] memory mentoV2Proxies = Arrays.addresses(brokerProxy, biPoolManagerProxy, reserveProxy);
+    address[] memory mentoV2Proxies = Arrays.addresses(
+      brokerProxy,
+      biPoolManagerProxy,
+      reserveProxy,
+      sortedOraclesProxy
+    );
     for (uint i = 0; i < mentoV2Proxies.length; i++) {
       transferOwnership(mentoV2Proxies[i]);
       transferProxyAdmin(mentoV2Proxies[i]);

--- a/script/upgrades/MU08/MU08.sol
+++ b/script/upgrades/MU08/MU08.sol
@@ -385,11 +385,6 @@ contract MU08 is IMentoUpgrade, GovernanceScript {
     // so we only need to transfer ownership of that single contract.
     address sharedImplementation = IProxyLite(cUSDProxy)._getImplementation();
     for (uint i = 0; i < tokenProxies.length; i++) {
-      if (tokenProxies[i] == cGHSProxy) {
-        // cGHS is not yet initialized, so it doesn't have an implementation
-        continue;
-      }
-
       require(
         IProxyLite(tokenProxies[i])._getImplementation() == sharedImplementation,
         "Token proxies not poiting to cUSD implementation"
@@ -437,12 +432,8 @@ contract MU08 is IMentoUpgrade, GovernanceScript {
   }
 
   function transferOwnership(address contractAddr) internal {
-    bool isGHS = contractAddr == cGHSProxy;
-
-    if (
-      isGHS ||
-      (IOwnableLite(contractAddr).owner() != timelockProxy && IOwnableLite(contractAddr).owner() == celoGovernance)
-    ) {
+    address contractOwner = IOwnableLite(contractAddr).owner();
+    if (contractOwner != timelockProxy && contractOwner == celoGovernance) {
       transactions.push(
         ICeloGovernance.Transaction({
           value: 0,
@@ -454,12 +445,8 @@ contract MU08 is IMentoUpgrade, GovernanceScript {
   }
 
   function transferProxyAdmin(address contractAddr) internal {
-    bool isGHS = contractAddr == cGHSProxy;
-
-    if (
-      isGHS ||
-      (IProxyLite(contractAddr)._getOwner() != timelockProxy && IProxyLite(contractAddr)._getOwner() == celoGovernance)
-    ) {
+    address proxyAdmin = IProxyLite(contractAddr)._getOwner();
+    if (proxyAdmin != timelockProxy && proxyAdmin == celoGovernance) {
       transactions.push(
         ICeloGovernance.Transaction({
           value: 0,

--- a/script/upgrades/MU08/MU08Checks.sol
+++ b/script/upgrades/MU08/MU08Checks.sol
@@ -52,6 +52,7 @@ contract MU08Checks is GovernanceScript, Test {
   address private brokerProxy;
   address private biPoolManagerProxy;
   address private reserveProxy;
+  address private sortedOraclesProxy;
   address private breakerBox;
   address private medianDeltaBreaker;
   address private valueDeltaBreaker;
@@ -112,6 +113,7 @@ contract MU08Checks is GovernanceScript, Test {
     brokerProxy = address(uint160(contracts.deployed("BrokerProxy")));
     biPoolManagerProxy = address(uint160(contracts.deployed("BiPoolManagerProxy")));
     reserveProxy = address(uint160(contracts.celoRegistry("Reserve")));
+    sortedOraclesProxy = address(uint160(contracts.celoRegistry("SortedOracles")));
     breakerBox = address(uint160(contracts.deployed("BreakerBox")));
     medianDeltaBreaker = address(uint160(contracts.deployed("MedianDeltaBreaker")));
     valueDeltaBreaker = address(uint160(contracts.deployed("ValueDeltaBreaker")));
@@ -300,7 +302,12 @@ contract MU08Checks is GovernanceScript, Test {
 
   function verifyMentoV2Ownership() public {
     console.log("\n== Verifying MentoV2 contract ownerships: ==");
-    address[] memory mentoV2Proxies = Arrays.addresses(brokerProxy, biPoolManagerProxy, reserveProxy);
+    address[] memory mentoV2Proxies = Arrays.addresses(
+      brokerProxy,
+      biPoolManagerProxy,
+      reserveProxy,
+      sortedOraclesProxy
+    );
     for (uint256 i = 0; i < mentoV2Proxies.length; i++) {
       verifyProxyAndImplementationOwnership(mentoV2Proxies[i]);
     }


### PR DESCRIPTION
### Description

This adds the sorted oracles proxy ownership transfer to MU08

### Other changes

Removed some no longer needed code around cGHS

### Tested

Simulations are green. Note that the implementation of the sorted oracles contract is not owned by Celo Governance and therefore can't be transferred:

>   🟢 Proxy:[0xefB84935239dAcdecF7c5bA76d8dE40b077B7b33] ownership transferred to Mento Governance
  🟢 Proxy:[0xefB84935239dAcdecF7c5bA76d8dE40b077B7b33] admin ownership transferred to Mento Governance
  🟡 Warning Implementation:[0x93da60DCdDA3229246769CcE307076C181F41F72] ownership not transferred to Mento Governance 🟡
