### PR TITLE
feat: MGP-7: MENTO token transferability

### DIFF
--- a/script/upgrades/MGP07/MGP07.md
+++ b/script/upgrades/MGP07/MGP07.md
@@ -1,6 +1,6 @@
 ## TL;DR
 
-This proposal unpauses the Mento Token, enabling normal token transfers for all users. Initially launched as a non-transferable governance token, the MENTO token was designed with a future option to become transferable contingent upon the protocol’s maturity, as well as community and market readiness. Given Mento's significant progress, product traction, and strategic focus on stablecoin-based onchain FX markets, enabling token transferability is now timely and beneficial for the protocol's continued growth and decentralization.
+This proposal enables MENTO token transfers for all users by unpausing the Mento Token. Initially launched as a non-transferable governance token, the MENTO token was designed with a future option to become transferable contingent upon the protocol’s maturity, as well as community and market readiness. Given Mento's significant progress, product traction, and strategic focus on stablecoin-based onchain FX markets, enabling token transferability is now timely and beneficial for the protocol's continued growth and decentralization.
 
 ### Motivation
 

--- a/script/upgrades/MGP07/MGP07.md
+++ b/script/upgrades/MGP07/MGP07.md
@@ -1,0 +1,44 @@
+## TL;DR
+
+This proposal unpauses the Mento Token, enabling normal token transfers for all users. Initially launched as a non-transferable governance token, the MENTO token was designed with a future option to become transferable contingent upon the protocol’s maturity, as well as community and market readiness. Given Mento's significant progress, product traction, and strategic focus on stablecoin-based onchain FX markets, enabling token transferability is now timely and beneficial for the protocol's continued growth and decentralization.
+
+### Motivation
+
+Activating MENTO token transferability is expected to:
+
+- **enhance liquidity and accessibility**, enabling a wider and more diverse group of stakeholders to actively participate in Mento governance;
+- **facilitate deeper decentralization** by incentivizing and empowering new contributors, further distributing governance influence across the community;
+- **strengthen the protocol's resilience and community ownership** by further decentralizing token holdings;
+- **align token utility with current market expectations**, working towards tangible economic incentives that drive innovation, active participation, and strategic collaborations within the broader decentralized finance ecosystem.
+
+### Rationale
+
+Mento has reached significant milestones demonstrating the community's readiness for token transferability:
+
+- **Mento decentralized local currency stablecoins** are among the growing stablecoins in the industry with 15 local stablecoins live, that include all G7s and key African, LatAm, and South East Asian currencies
+- **The Mento Asset Exchange**, integrated into leading solutions like Squid Router or Opera MiniPay, processed over 550 million transactions in 2024
+- **Mento has over 8m users** with around 400k daily active users and strategic partnerships with major global organizations, including Deutsche Telekom, Opera, Chainlink, RedStone, Valora, Fonbnk, Yellow Card, and many more
+- **MENTO is about to unlock the next stage of growth** with onchain FX trading
+
+### Transaction Details
+
+This proposal consists of one transaction:
+
+**TX#0:** call the `unpause()` function on the MentoToken contract
+
+- Target: MentoToken contract
+- Function: `unpause()`
+- Parameters: None
+
+**Relevant Addresses for verification**
+
+- MentoToken
+  - [_0x7FF62f59e3e89EA34163EA1458EEBCc81177Cfb6_](https://celoscan.io/address/0x7FF62f59e3e89EA34163EA1458EEBCc81177Cfb6)
+
+### Legal disclaimer
+
+Mento is a decentralized and community-governed platform. This is not an offer to sell or the solicitation of an offer to purchase any MENTO tokens, and is not an offering, advertisement, solicitation, confirmation, statement or any financial promotion that can be construed as an invitation or inducement to engage in any investment activity or similar. You should not rely on the content here for advice of any kind, including legal, investment, financial, tax, or other professional advice, and such content is not a substitute for advice from a qualified professional.
+
+The token utility explorations should be seen merely as preliminary conceptual ideas, which are likely to be subject to substantial change. Before any implementation, extensive analysis is required to get a clear picture on aspects such as legal/regulatory risks, technical feasibility, resource availability, product roadmap etc.
+
+Any documentation or statements are provided for informational purposes only and do not constitute financial advice, a prospectus, a key information document, or any other similar document. No prospectus, key information document, or similar document will be provided at any time. There is no guarantee of the completeness and accuracy of the documentation statements provided. All numbers and forward-looking statements mentioned here in the forum, as well as any accompanying documentation and/or statements reflect mere estimations/indications. They are not guaranteed and may change substantially.

--- a/script/upgrades/MGP07/MGP07.sol
+++ b/script/upgrades/MGP07/MGP07.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// solhint-disable func-name-mixedcase, contract-name-camelcase, function-max-lines, var-name-mixedcase
+pragma solidity ^0.8;
+pragma experimental ABIEncoderV2;
+
+import { GovernanceScript } from "script/utils/mento/Script.sol";
+import { Contracts } from "script/utils/mento/Contracts.sol";
+import { Chain } from "script/utils/mento/Chain.sol";
+
+import { IGovernanceFactory } from "script/interfaces/IGovernanceFactory.sol";
+import { IMentoUpgrade, ICeloGovernance } from "script/interfaces/IMentoUpgrade.sol";
+import { IGovernor } from "script/interfaces/IGovernor.sol";
+
+interface IMentoTokenLite {
+  function unpause() external;
+
+  function paused() external view returns (bool);
+
+  function owner() external view returns (address);
+
+  function balanceOf(address account) external view returns (uint256);
+
+  function transfer(address to, uint256 amount) external returns (bool);
+
+  function transferFrom(address from, address to, uint256 amount) external returns (bool);
+}
+
+contract MGP07 is IMentoUpgrade, GovernanceScript {
+  using Contracts for Contracts.Cache;
+
+  bool public hasChecks = true;
+
+  address public mentoGovernor;
+  address public mentoToken;
+
+  IGovernanceFactory public governanceFactory;
+
+  function loadDeployedContracts() public {
+    contracts.loadSilent("MUGOV-00-Create-Factory", "latest");
+  }
+
+  function prepare() public {
+    loadDeployedContracts();
+
+    governanceFactory = IGovernanceFactory(contracts.deployed("GovernanceFactory"));
+
+    mentoGovernor = governanceFactory.mentoGovernor();
+    require(mentoGovernor != address(0), "MentoGovernor address not found");
+
+    mentoToken = governanceFactory.mentoToken();
+    require(mentoToken != address(0), "MentoToken address not found");
+  }
+
+  function run() public {
+    prepare();
+
+    ICeloGovernance.Transaction[] memory _transactions = buildProposal();
+
+    vm.startBroadcast(Chain.deployerPrivateKey());
+    {
+      createStructuredProposal(
+        "MGP-7: Enable Mento Token transferability",
+        "./script/upgrades/MGP07/MGP07.md",
+        _transactions,
+        mentoGovernor
+      );
+    }
+    vm.stopBroadcast();
+  }
+
+  function buildProposal() public returns (ICeloGovernance.Transaction[] memory) {
+    ICeloGovernance.Transaction[] memory _transactions = new ICeloGovernance.Transaction[](1);
+
+    require(IMentoTokenLite(mentoToken).paused(), "MentoToken is not paused");
+
+    _transactions[0] = ICeloGovernance.Transaction(
+      0,
+      mentoToken,
+      abi.encodeWithSelector(IMentoTokenLite.unpause.selector)
+    );
+
+    return _transactions;
+  }
+}

--- a/script/upgrades/MGP07/MGP07Checks.sol
+++ b/script/upgrades/MGP07/MGP07Checks.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8;
+pragma experimental ABIEncoderV2;
+/* solhint-disable max-line-length */
+
+import { GovernanceScript } from "script/utils/mento/Script.sol";
+import { console2 as console } from "forge-std/console2.sol";
+import { Contracts } from "script/utils/mento/Contracts.sol";
+import { Test } from "forge-std/Test.sol";
+import { Chain } from "script/utils/mento/Chain.sol";
+
+import { IGovernanceFactory } from "script/interfaces/IGovernanceFactory.sol";
+import { IGovernor } from "script/interfaces/IGovernor.sol";
+
+import { IMentoTokenLite } from "./MGP07.sol";
+
+contract MGP07Checks is GovernanceScript, Test {
+  using Contracts for Contracts.Cache;
+
+  address public mentoToken;
+  IGovernanceFactory governanceFactory;
+
+  function prepare() public {
+    contracts.loadSilent("MUGOV-00-Create-Factory", "latest");
+
+    address governanceFactoryAddress = contracts.deployed("GovernanceFactory");
+    require(governanceFactoryAddress != address(0), "GovernanceFactory address not found");
+    governanceFactory = IGovernanceFactory(governanceFactoryAddress);
+
+    mentoToken = governanceFactory.mentoToken();
+    require(mentoToken != address(0), "MentoToken address not found");
+
+    console.log("MentoToken address:", mentoToken);
+  }
+
+  function run() public {
+    console.log("\nStarting MGP07 checks:");
+    prepare();
+
+    verifyTokenUnpaused();
+    verifyTokenTransfer();
+  }
+
+  function verifyTokenUnpaused() public view {
+    console.log("\n== Verifying token unpause: ==");
+
+    require(!IMentoTokenLite(mentoToken).paused(), "MentoToken is still paused");
+    console.log(unicode"🟢 MentoToken is unpaused");
+  }
+
+  function verifyTokenTransfer() public {
+    console.log("\n== Verifying token transfer functionality: ==");
+
+    address airgrab = governanceFactory.airgrab();
+    uint256 airgrabBalance = IMentoTokenLite(mentoToken).balanceOf(airgrab);
+    require(airgrabBalance > 0, "Airgrab contract has no tokens");
+
+    address receiver = address(123);
+    uint256 transferAmount = 345 ether;
+
+    vm.startPrank(airgrab);
+    IMentoTokenLite(mentoToken).transfer(receiver, transferAmount);
+    require(
+      IMentoTokenLite(mentoToken).balanceOf(airgrab) == airgrabBalance - transferAmount,
+      "Airgrab balance is incorrect"
+    );
+    require(IMentoTokenLite(mentoToken).balanceOf(receiver) == transferAmount, "Receiver balance is incorrect");
+    vm.stopPrank();
+
+    console.log(unicode"🟢 Token transfers work");
+  }
+}


### PR DESCRIPTION
### Description

MGP to enable the transferability of the MENTO token.

### Other changes

N/A

### Tested

Wrote checks for:

- checking that the state of the contract is "unpaused"
- simulating a token transfer from a token holder address
